### PR TITLE
Add type annotation to not crash newer pyright

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,12 @@ jobs: # A basic unit of work in a run
             source $VENV_HOME_DIR/bin/activate
             pytest -s
       - run:
-          # FIXME Fix type-checking for pyright 1.1.20 https://github.com/Meeshkan/meeshkan/issues/1
           name: Install pyright and run typecheck
           command: |
             set +e
             echo 'export PATH=$(yarn global bin):$PATH' >> $BASH_ENV
             source $BASH_ENV
-            yarn global add pyright@1.1.13
+            yarn global add pyright
             export VENV_HOME_DIR=$(pipenv --venv)
             source $VENV_HOME_DIR/bin/activate
             pyright --lib

--- a/meeshkan/schemabuilder/builder.py
+++ b/meeshkan/schemabuilder/builder.py
@@ -211,7 +211,7 @@ def update(schema: OpenAPIObject, request: RequestResponse) -> OpenAPIObject:
 
     if request['req']['path'] in schema_copy['paths']:
         # Path item exists for request path
-        path_item = schema_copy['paths'][request['req']['path']]
+        path_item: PathItem = schema_copy['paths'][request['req']['path']]
     else:
         path_item = PathItem(summary="Path summary",
                              description="Path description")


### PR DESCRIPTION
Without this type annotation pyright >= 1.1.14 fails with a:

    RangeError: Maximum call stack size exceeded

Fixes #1.