### PR TITLE
Add entrypoint to CLI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Reverse engineer services with style 🤓💾🚀
 Build OpenAPI schema from API recordings:
 
 ```bash
-$ python -m meeshkan < resources/sample.jsonl
+$ meeshkan < resources/sample.jsonl
 ```
 
 ### Tests

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ DEV = [
 
 VERSION = '0.0.0'
 
+ENTRY_POINTS = ['meeshkan = meeshkan.__main__:main']
+
 # Optional packages
 EXTRAS = {'dev': DEV}
 
@@ -122,6 +124,7 @@ setup(name=NAME,
           'Operating System :: OS Independent',
       ],
       zip_safe=False,
+      entry_points={'console_scripts': ENTRY_POINTS},
       cmdclass={'dist': BuildDistCommand,
                 'test': TestCommand,
                 'typecheck': TypeCheckCommand}


### PR DESCRIPTION
Enables accessing CLI as `meeshkan` instead of `python -m meeshkan`.