### PR TITLE
Write builder output to folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 .ipynb_checkpoints/
 .testmondata
 *.egg-info/
+out/

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -26,7 +26,7 @@ def cli():
 
 @click.command()
 @click.option("-i", "--input-file", required=True, type=click.File('rb'), help="Input file. Use dash '-' to read from stdin.")
-@click.option("-o", "--out", required=False, default='out', type=click.Path(exists=False, file_okay=False, writable=True, readable=True), help="Output folder. If the folder does not exist, the parent directory must exist.")
+@click.option("-o", "--out", required=False, default='out', type=click.Path(exists=False, file_okay=False, writable=True, readable=True), help="Output directory. If the directory does not exist, it is created if the parent directory exists.")
 def build(input_file, out):
     """
     Build OpenAPI schema from recordings.

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -26,7 +26,7 @@ def cli():
 
 @click.command()
 @click.option("-i", "--input-file", required=True, type=click.File('rb'), help="Input file. Use dash '-' to read from stdin.")
-@click.option("-o", "--out", required=False, default='out', type=click.Path(exists=False, file_okay=False, writable=True, readable=True), help="Output folder. If omitted, output is to.")
+@click.option("-o", "--out", required=False, default='out', type=click.Path(exists=False, file_okay=False, writable=True, readable=True), help="Output folder. If the folder does not exist, the parent directory must exist.")
 def build(input_file, out):
     """
     Build OpenAPI schema from recordings.

--- a/meeshkan/schemabuilder/result.py
+++ b/meeshkan/schemabuilder/result.py
@@ -1,0 +1,8 @@
+
+
+from typing_extensions import TypedDict
+from openapi_typed import OpenAPIObject
+
+
+class BuildResult(TypedDict):
+    openapi: OpenAPIObject

--- a/meeshkan/schemabuilder/writer.py
+++ b/meeshkan/schemabuilder/writer.py
@@ -13,7 +13,7 @@ LOGGER = getLogger(__name__)
 OPENAPI_FILENAME = 'openapi.yaml'
 
 
-def read_openapi(file: Path) -> OpenAPIObject:
+def _read_openapi(file: Path) -> OpenAPIObject:
     """Read an OpenAPI YAML from file.
 
     Arguments:
@@ -38,18 +38,18 @@ def read_directory(directory: str) -> BuildResult:
     Returns:
         BuildResult -- Build result.
     """
-    path = resolve_path(directory)
+    path = _resolve_path(directory)
 
     if not path.is_dir():
         raise FileNotFoundError("Cannot read from {}".format(str(path)))
 
     openapi_path = path / OPENAPI_FILENAME
-    openapi_object = read_openapi(openapi_path)
+    openapi_object = _read_openapi(openapi_path)
 
     return BuildResult(openapi=openapi_object)
 
 
-def ensure_dir_exists(path: Path) -> None:
+def _ensure_dir_exists(path: Path) -> None:
     """Ensure directory at `path` exists. Does NOT create parent directories.
 
     Arguments:
@@ -61,7 +61,7 @@ def ensure_dir_exists(path: Path) -> None:
     path.mkdir(parents=False, exist_ok=True)
 
 
-def resolve_path(directory: str) -> Path:
+def _resolve_path(directory: str) -> Path:
     """Return directory as absolute Path.
 
     Arguments:
@@ -81,10 +81,10 @@ def write_build_result(directory: str, result: BuildResult) -> None:
         directory {str} -- Directory where to write results, possibly relative.
         result {BuildResult} -- Builder result.
     """
-    output_dir_path = resolve_path(directory)
+    output_dir_path = _resolve_path(directory)
     LOGGER.info("Writing to folder %s.", str(output_dir_path))
 
-    ensure_dir_exists(output_dir_path)
+    _ensure_dir_exists(output_dir_path)
 
     openapi_output = output_dir_path / OPENAPI_FILENAME
 

--- a/meeshkan/schemabuilder/writer.py
+++ b/meeshkan/schemabuilder/writer.py
@@ -1,0 +1,97 @@
+"""Code for writing builder results to file system.
+"""
+from openapi_typed import OpenAPIObject
+from .result import BuildResult
+import yaml
+from ..logger import get as getLogger
+from typing import cast
+from pathlib import Path
+
+LOGGER = getLogger(__name__)
+
+
+OPENAPI_FILENAME = 'openapi.yaml'
+
+
+def read_openapi(file: Path) -> OpenAPIObject:
+    """Read an OpenAPI YAML from file.
+
+    Arguments:
+        file {Path} -- Path to OpenAPI YAML file.
+
+    Returns:
+        OpenAPIObject -- OpenAPI object.
+    """
+    with file.open('rb') as f:
+        return cast(OpenAPIObject, yaml.safe_load(f))
+
+
+def read_directory(directory: str) -> BuildResult:
+    """Read BuildResult from directory.
+
+    Arguments:
+        directory {str} -- Directory to read, possibly relative.
+
+    Raises:
+        FileNotFoundError: If directory is not an existing directory.
+
+    Returns:
+        BuildResult -- Build result.
+    """
+    path = resolve_path(directory)
+
+    if not path.is_dir():
+        raise FileNotFoundError("Cannot read from {}".format(str(path)))
+
+    openapi_path = path / OPENAPI_FILENAME
+    openapi_object = read_openapi(openapi_path)
+
+    return BuildResult(openapi=openapi_object)
+
+
+def ensure_dir_exists(path: Path) -> None:
+    """Ensure directory at `path` exists. Does NOT create parent directories.
+
+    Arguments:
+        path {Path} -- Path to the directory to create.
+
+    Raises:
+        FileNotFoundError -- If the directory does not exist and its parents do not exist.
+    """
+    path.mkdir(parents=False, exist_ok=True)
+
+
+def resolve_path(directory: str) -> Path:
+    """Return directory as absolute Path.
+
+    Arguments:
+        directory {str} -- Path to directory, possibly relative.
+
+    Returns:
+        Path -- Absolute Path.
+    """
+    path = Path(directory)
+    return path.resolve()
+
+
+def write_build_result(directory: str, result: BuildResult) -> None:
+    """Write builder result to a directory.
+
+    Arguments:
+        directory {str} -- Directory where to write results, possibly relative.
+        result {BuildResult} -- Builder result.
+    """
+    output_dir_path = resolve_path(directory)
+    LOGGER.info("Writing to folder %s.", str(output_dir_path))
+
+    ensure_dir_exists(output_dir_path)
+
+    openapi_output = output_dir_path / OPENAPI_FILENAME
+
+    openapi_object = result['openapi']
+
+    schema_yaml = cast(str, yaml.safe_dump(openapi_object))
+
+    with openapi_output.open('wb') as f:
+        LOGGER.debug("Writing to: %s\n", str(openapi_output))
+        f.write(schema_yaml.encode(encoding="utf-8"))


### PR DESCRIPTION
Closes #9.

- Takes a directory as output destination. Defaults to `out/`.
- Currently only writes `openapi.yaml` in the destination.
- Added some reading and writing code and a very simple data type for the build result.

- [x]  Rebase on logging config branch once that's merged.