### PR TITLE
Be zsh compatible in the README instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Reverse engineer services with style 🤓💾🚀
 ### Getting started
 
 1. Create virtual environment
-1. Install dependencies: `pip install --upgrade -e .[dev]`
+1. Install dependencies: `pip install --upgrade -e '.[dev]'`
 
 ### Invoking CLI
 


### PR DESCRIPTION
We lost this in the transition from unmock-sniffer:

Without the quotes around `[]`, zsh (which is the default shell on macOS nowadays), fails with `zsh: no matches found: .[dev]`. 