### PR TITLE
Add code for manipulating path parameters.

### DIFF
--- a/meeshkan/schemabuilder/__init__.py
+++ b/meeshkan/schemabuilder/__init__.py
@@ -1,3 +1,3 @@
 """OpenAPI schema building operations. Uses request-response pairs as input.
 """
-from .builder import build_schema_batch, build_schema_online
+from .builder import build_schema_batch, build_schema_online, update_openapi

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -1,11 +1,13 @@
 """Code for working with OpenAPI paths, combining and transforming them."""
 import re
-from typing import Pattern
+from typing import Pattern, Optional, Tuple, Mapping, Any, Sequence
 
+from openapi_typed import PathItem, Paths
 
+# Al regex replacements must be capturing groups
 TYPE_TO_REGEX = {
-    'string': r"""\w+""",
-    'number': r"""\d+""",
+    'string': r"""(\w+)""",
+    'number': r"""(\d+)""",
 }
 
 # Pattern to match to in the escaped path string
@@ -13,7 +15,52 @@ TYPE_TO_REGEX = {
 PATH_PARAMETER_PATTERN = r"""\\{([\w-]+)\\}"""
 
 
-def path_to_regex(path: str, **kwargs) -> Pattern[str]:
+def match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
+    """Match a request path to path
+
+    Arguments:
+        request_path {str} -- Request path such as /pets/32
+        path {str} -- Path name in OpenAPI format such as /pets/{id}
+
+    Returns:
+        Optional[Mapping[str, Any]] -- None if no match, dictionary of parameter name to value otherwise.
+    """
+    path_as_regex, parameter_names = path_to_regex(path)
+    match = path_as_regex.match(request_path)
+
+    if match is None:
+        return None
+
+    captures = match.groups()
+
+    assert len(parameter_names) == len(captures)
+
+    return {key: value for key, value in zip(parameter_names, captures)}
+
+
+def find_matching_path(request_path: str, paths: Paths) -> Optional[Tuple[PathItem, Mapping[str, Any]]]:
+    """Find path that matches the request.
+
+    Arguments:
+        request_path {str} -- Request path.
+        paths {Paths} -- OpenAPI Paths object.
+
+    Returns:
+        Optional[Tuple[PathItem, Mapping[str, Any]]] -- PathItem and key-value pairs of found path parameters with names
+    """
+
+    for path, path_item in paths.items():
+        path_match = match_to_path(request_path, path)
+
+        if path_match is None:
+            continue
+
+        return (path_item, path_match)
+
+    return None
+
+
+def path_to_regex(path: str, **kwargs) -> Tuple[Pattern[str], Tuple[str]]:
     """Convert an OpenAPI path such as "/pets/{id}" to a regular expression.
 
     Arguments:
@@ -21,13 +68,15 @@ def path_to_regex(path: str, **kwargs) -> Pattern[str]:
         kwargs: Keyword arguments listing the type of each parameter: For example: { 'id': { 'type': 'string' } }
 
     Returns:
-        {str} -- Pattern for path with parameters replaced by regular expressions.
+        {} -- Tuple containing (1) pattern for path with parameters replaced by regular expressions, and (2) list of parameters with names.
     """
 
     # Work on string whose regex characters are escaped ("/"" becomes "//" etc.)
     # This makes it easier to replace matches with regular expressions.
     # For example: /pets/{id} becomes \/pets\/\{id\}
     escaped_path = re.escape(path)
+
+    param_names = ()  # type: Tuple[str]
 
     for match in re.finditer(PATH_PARAMETER_PATTERN, escaped_path):
         full_match = match.group(0)
@@ -44,6 +93,8 @@ def path_to_regex(path: str, **kwargs) -> Pattern[str]:
 
         type_regex = TYPE_TO_REGEX[param_type]
 
+        param_names = param_names + (param_name, )
+
         escaped_path = escaped_path.replace(full_match, type_regex)
 
-    return re.compile(r'^' + escaped_path + r'$')
+    return (re.compile(r'^' + escaped_path + r'$'), param_names)

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -12,14 +12,14 @@ RequestPathParameters = Mapping[str, str]
 
 
 def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
-    """Match a request path to path
+    """Match a request path such as "/pets/32" to a variable path such as "/pets/{petId}".
 
     Arguments:
         request_path {str} -- Request path such as /pets/32
         path {str} -- Path name in OpenAPI format such as /pets/{id}
 
     Returns:
-        Optional[Mapping[str, Any]] -- None if no match, dictionary of parameter name to value otherwise.
+        Optional[Mapping[str, Any]] -- None if the paths do not match. Otherwise, return a dictionary of parameter names to values (for example: { 'petId': '32' })
     """
     path_as_regex, parameter_names = path_to_regex(path)
     match = path_as_regex.match(request_path)
@@ -29,7 +29,8 @@ def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
 
     captures = match.groups()
 
-    assert len(parameter_names) == len(captures)
+    assert len(parameter_names) == len(
+        captures), "Expected the number of parameter names in the path to match the number of captured parameter values"
 
     return {parameter_name: parameter_value for parameter_name, parameter_value in zip(parameter_names, captures)}
 

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -83,6 +83,6 @@ def path_to_regex(path: str) -> Tuple[Pattern[str], Tuple[str]]:
 
         escaped_path = escaped_path.replace(full_match, PATH_PARAMETER_REGEX)
 
-    regex_pattern = re.compile(r'^' + escaped_path + r'(?=\?|$)')
+    regex_pattern = re.compile(r'^' + escaped_path + r'(?:\?|$)')
 
     return (regex_pattern, param_names)

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -83,6 +83,6 @@ def path_to_regex(path: str) -> Tuple[Pattern[str], Tuple[str]]:
 
         escaped_path = escaped_path.replace(full_match, PATH_PARAMETER_REGEX)
 
-    regex_pattern = re.compile(r'^' + escaped_path + r'(?:\?|$)')
+    regex_pattern = re.compile(r'^' + escaped_path + r'(?:\?|#|$)')
 
     return (regex_pattern, param_names)

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -24,9 +24,6 @@ def path_to_regex(path: str, **kwargs) -> Pattern[str]:
         {str} -- Pattern for path with parameters replaced by regular expressions.
     """
 
-    # Extract parameters
-    param_name = 'id'
-
     # Work on string whose regex characters are escaped ("/"" becomes "//" etc.)
     # This makes it easier to replace matches with regular expressions.
     # For example: /pets/{id} becomes \/pets\/\{id\}

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -1,0 +1,37 @@
+"""Code for working with OpenAPI paths, combining and transforming them."""
+import re
+
+
+TYPE_TO_REGEX = {
+    'string': re.compile(r"""\w+"""),
+    'number': re.compile(r"""\d+"""),
+}
+
+
+def path_to_regex(path: str, **kwargs):
+    """Convert an OpenAPI path such as "/pets/{id}" to a regular expression.
+
+    Arguments:
+        path {str} -- [description]
+        kwargs: Keyword arguments listing the type of each parameter: For example: { 'id': { 'type': 'string' } }
+    """
+
+    # Extract parameters
+    param_name = 'id'
+
+    param_pattern = r"""\\{([\w-]+)\\}"""
+
+    return_string = re.escape(path)
+
+    for match in re.finditer(param_pattern, return_string):
+        full_match = match.group(0)
+        param_name = match.group(1)
+        if not param_name in kwargs:
+            raise Exception(
+                "No match for parameter %s in kwargs".format(param_name))
+        param_type = kwargs[param_name]['type']
+        type_regex = TYPE_TO_REGEX[param_type]
+
+        return_string = return_string.replace(full_match, type_regex.pattern)
+
+    return re.compile(r'^' + return_string + r'$')

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -1,4 +1,4 @@
-"""Code for working with OpenAPI paths, combining and transforming them."""
+"""Code for working with OpenAPI paths, e.g., matching request path to an OpenAPI endpoint with parameter."""
 import re
 from typing import Pattern, Optional, Tuple, Mapping, Any, Sequence
 
@@ -15,7 +15,7 @@ TYPE_TO_REGEX = {
 PATH_PARAMETER_PATTERN = r"""\\{([\w-]+)\\}"""
 
 
-def match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
+def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
     """Match a request path to path
 
     Arguments:
@@ -50,7 +50,7 @@ def find_matching_path(request_path: str, paths: Paths) -> Optional[Tuple[PathIt
     """
 
     for path, path_item in paths.items():
-        path_match = match_to_path(request_path, path)
+        path_match = _match_to_path(request_path=request_path, path=path)
 
         if path_match is None:
             continue

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -8,6 +8,10 @@ TYPE_TO_REGEX = {
     'number': r"""\d+""",
 }
 
+# Pattern to match to in the escaped path string
+# Search for occurrences such as "{id}" or "{key-name}"
+PATH_PARAMETER_PATTERN = r"""\\{([\w-]+)\\}"""
+
 
 def path_to_regex(path: str, **kwargs) -> Pattern[str]:
     """Convert an OpenAPI path such as "/pets/{id}" to a regular expression.
@@ -24,14 +28,11 @@ def path_to_regex(path: str, **kwargs) -> Pattern[str]:
     param_name = 'id'
 
     # Work on string whose regex characters are escaped ("/"" becomes "//" etc.)
+    # This makes it easier to replace matches with regular expressions.
     # For example: /pets/{id} becomes \/pets\/\{id\}
     escaped_path = re.escape(path)
 
-    # Pattern to match to in the escaped path string
-    # Search for occurrences such as "{id}" or "{key-name}"
-    param_pattern = r"""\\{([\w-]+)\\}"""
-
-    for match in re.finditer(param_pattern, escaped_path):
+    for match in re.finditer(PATH_PARAMETER_PATTERN, escaped_path):
         full_match = match.group(0)
         param_name = match.group(1)
         if not param_name in kwargs:

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -33,7 +33,7 @@ def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
 
 
 def find_matching_path(request_path: str, paths: Paths) -> Optional[Tuple[PathItem, Mapping[str, Any]]]:
-    """Find path that matches the request.
+    """Find path that matches the request path.
 
     Arguments:
         request_path {str} -- Request path.
@@ -83,6 +83,6 @@ def path_to_regex(path: str) -> Tuple[Pattern[str], Tuple[str]]:
 
         escaped_path = escaped_path.replace(full_match, PATH_PARAMETER_REGEX)
 
-    regex_pattern = re.compile(r'^' + escaped_path + r'$')
+    regex_pattern = re.compile(r'^' + escaped_path + r'(?=\?|$)')
 
     return (regex_pattern, param_names)

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -1,5 +1,6 @@
 """Code for working with OpenAPI paths, combining and transforming them."""
 import re
+from typing import Pattern
 
 
 TYPE_TO_REGEX = {
@@ -8,12 +9,15 @@ TYPE_TO_REGEX = {
 }
 
 
-def path_to_regex(path: str, **kwargs):
+def path_to_regex(path: str, **kwargs) -> Pattern[str]:
     """Convert an OpenAPI path such as "/pets/{id}" to a regular expression.
 
     Arguments:
         path {str} -- [description]
         kwargs: Keyword arguments listing the type of each parameter: For example: { 'id': { 'type': 'string' } }
+
+    Returns:
+        {str} -- Pattern for path with parameters replaced by regular expressions.
     """
 
     # Extract parameters
@@ -24,6 +28,7 @@ def path_to_regex(path: str, **kwargs):
     escaped_path = re.escape(path)
 
     # Pattern to match to in the escaped path string
+    # Search for occurrences such as "{id}" or "{key-name}"
     param_pattern = r"""\\{([\w-]+)\\}"""
 
     for match in re.finditer(param_pattern, escaped_path):

--- a/meeshkan/schemabuilder/paths.py
+++ b/meeshkan/schemabuilder/paths.py
@@ -8,6 +8,8 @@ from openapi_typed import PathItem, Paths
 # Search for occurrences such as "{id}" or "{key-name}"
 PATH_PARAMETER_PATTERN = r"""\\{([\w-]+)\\}"""
 
+RequestPathParameters = Mapping[str, str]
+
 
 def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
     """Match a request path to path
@@ -32,7 +34,7 @@ def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
     return {parameter_name: parameter_value for parameter_name, parameter_value in zip(parameter_names, captures)}
 
 
-def find_matching_path(request_path: str, paths: Paths) -> Optional[Tuple[PathItem, Mapping[str, Any]]]:
+def find_matching_path(request_path: str, paths: Paths) -> Optional[Tuple[PathItem, RequestPathParameters]]:
     """Find path that matches the request path.
 
     Arguments:

--- a/tests/schemabuilder/builder_test.py
+++ b/tests/schemabuilder/builder_test.py
@@ -117,5 +117,5 @@ class TestPetstoreSchemaUpdate:
         orig_path_item = PETSTORE_SCHEMA['paths']['/pets/{petId}']
         updated_path_item = updated_schema['paths']['/pets/{petId}']
 
-        # TODO Should builder update this instead of being no-op?
+        # TODO Should builder update the path item instead of being no-op?
         assert_that(updated_path_item, equal_to(orig_path_item))

--- a/tests/schemabuilder/paths_test.py
+++ b/tests/schemabuilder/paths_test.py
@@ -1,23 +1,39 @@
-from meeshkan.schemabuilder.paths import path_to_regex
-from hamcrest import assert_that, matches_regexp, not_, is_
+from meeshkan.schemabuilder.paths import path_to_regex, find_matching_path
+from hamcrest import assert_that, matches_regexp, not_, is_, equal_to, has_entry
+from ..util import petstore_schema
+
+PETSTORE_SCHEMA = petstore_schema()
 
 
 def test_path_to_regex():
-    as_regex, parameters = path_to_regex('/pets/{id}', id={'type': 'number'})
+    as_regex, parameters = path_to_regex('/pets/{id}')
 
-    assert_that(as_regex.pattern, is_('^\\/pets\\/(\\d+)$'))
-    assert_that(as_regex.pattern, is_(r"""^\/pets\/(\d+)$"""))
+    assert_that(as_regex.pattern, is_('^\\/pets\\/(\\w+)$'))
+    assert_that(as_regex.pattern, is_(r"""^\/pets\/(\w+)$"""))
 
     assert_that("/pets/32", matches_regexp(as_regex))
     assert_that("/pets/32/", not_(matches_regexp(as_regex)))
-    assert_that("/pets/foo", not_(matches_regexp(as_regex)))
 
     assert parameters == ('id', )
 
 
 def test_path_to_regex_with_multiple_params():
     as_regex, _ = path_to_regex(
-        '/pets/{id}/items/{name}', id={'type': 'number'}, name={'type': 'string'})
+        '/pets/{id}/items/{name}')
 
-    assert_that("/pets/32/items/car", as_regex)
     assert_that("/pets/32/items/car", matches_regexp(as_regex))
+
+
+def test_match_paths():
+    paths = PETSTORE_SCHEMA['paths']
+    request_path = "/pets/32"
+
+    match_result = find_matching_path(request_path, paths)
+
+    assert match_result is not None
+
+    expected_path_item = PETSTORE_SCHEMA['paths']['/pets/{petId}']
+    path_item, parameters = match_result
+
+    assert_that(path_item, equal_to(expected_path_item))
+    assert_that(parameters, has_entry('petId', '32'))

--- a/tests/schemabuilder/paths_test.py
+++ b/tests/schemabuilder/paths_test.py
@@ -13,6 +13,7 @@ def test_path_to_regex():
 
     assert_that("/pets/32", matches_regexp(as_regex))
     assert_that("/pets/32?id=3", matches_regexp(as_regex))
+    assert_that("/pets/32#reference", matches_regexp(as_regex))
 
     assert_that("/pets/32/", not_(matches_regexp(as_regex)))
 

--- a/tests/schemabuilder/paths_test.py
+++ b/tests/schemabuilder/paths_test.py
@@ -5,6 +5,7 @@ def test_path_to_regex():
     as_regex = path_to_regex('/pets/{id}', id={'type': 'number'})
 
     assert as_regex.pattern == '^\\/pets\\/\\d+$'
-    assert as_regex.match("/pets/32")
-    assert not as_regex.match("/pets/32/")
-    assert not as_regex.match("/pets/foo")
+    assert as_regex.pattern == r"""^\/pets\/\d+$"""
+    assert as_regex.match("/pets/32"), "Expected /pets/32 to match"
+    assert not as_regex.match("/pets/32/"), "Did not expect /pets/32/ to match"
+    assert not as_regex.match("/pets/foo"), "Did not expect /pets/foo to match"

--- a/tests/schemabuilder/paths_test.py
+++ b/tests/schemabuilder/paths_test.py
@@ -3,18 +3,20 @@ from hamcrest import assert_that, matches_regexp, not_, is_
 
 
 def test_path_to_regex():
-    as_regex = path_to_regex('/pets/{id}', id={'type': 'number'})
+    as_regex, parameters = path_to_regex('/pets/{id}', id={'type': 'number'})
 
-    assert_that(as_regex.pattern, is_('^\\/pets\\/\\d+$'))
-    assert_that(as_regex.pattern, is_(r"""^\/pets\/\d+$"""))
+    assert_that(as_regex.pattern, is_('^\\/pets\\/(\\d+)$'))
+    assert_that(as_regex.pattern, is_(r"""^\/pets\/(\d+)$"""))
 
     assert_that("/pets/32", matches_regexp(as_regex))
     assert_that("/pets/32/", not_(matches_regexp(as_regex)))
     assert_that("/pets/foo", not_(matches_regexp(as_regex)))
 
+    assert parameters == ('id', )
+
 
 def test_path_to_regex_with_multiple_params():
-    as_regex = path_to_regex(
+    as_regex, _ = path_to_regex(
         '/pets/{id}/items/{name}', id={'type': 'number'}, name={'type': 'string'})
 
     assert_that("/pets/32/items/car", as_regex)

--- a/tests/schemabuilder/paths_test.py
+++ b/tests/schemabuilder/paths_test.py
@@ -8,10 +8,12 @@ PETSTORE_SCHEMA = petstore_schema()
 def test_path_to_regex():
     as_regex, parameters = path_to_regex('/pets/{id}')
 
-    assert_that(as_regex.pattern, is_('^\\/pets\\/(\\w+)$'))
-    assert_that(as_regex.pattern, is_(r"""^\/pets\/(\w+)$"""))
+    # assert_that(as_regex.pattern, is_('^\\/pets\\/(\\w+)$'))
+    # assert_that(as_regex.pattern, is_(r"""^\/pets\/(\w+)$"""))
 
     assert_that("/pets/32", matches_regexp(as_regex))
+    assert_that("/pets/32?id=3", matches_regexp(as_regex))
+
     assert_that("/pets/32/", not_(matches_regexp(as_regex)))
 
     assert parameters == ('id', )

--- a/tests/schemabuilder/paths_test.py
+++ b/tests/schemabuilder/paths_test.py
@@ -1,0 +1,10 @@
+from meeshkan.schemabuilder.paths import path_to_regex
+
+
+def test_path_to_regex():
+    as_regex = path_to_regex('/pets/{id}', id={'type': 'number'})
+
+    assert as_regex.pattern == '^\\/pets\\/\\d+$'
+    assert as_regex.match("/pets/32")
+    assert not as_regex.match("/pets/32/")
+    assert not as_regex.match("/pets/foo")

--- a/tests/schemabuilder/paths_test.py
+++ b/tests/schemabuilder/paths_test.py
@@ -1,11 +1,21 @@
 from meeshkan.schemabuilder.paths import path_to_regex
+from hamcrest import assert_that, matches_regexp, not_, is_
 
 
 def test_path_to_regex():
     as_regex = path_to_regex('/pets/{id}', id={'type': 'number'})
 
-    assert as_regex.pattern == '^\\/pets\\/\\d+$'
-    assert as_regex.pattern == r"""^\/pets\/\d+$"""
-    assert as_regex.match("/pets/32"), "Expected /pets/32 to match"
-    assert not as_regex.match("/pets/32/"), "Did not expect /pets/32/ to match"
-    assert not as_regex.match("/pets/foo"), "Did not expect /pets/foo to match"
+    assert_that(as_regex.pattern, is_('^\\/pets\\/\\d+$'))
+    assert_that(as_regex.pattern, is_(r"""^\/pets\/\d+$"""))
+
+    assert_that("/pets/32", matches_regexp(as_regex))
+    assert_that("/pets/32/", not_(matches_regexp(as_regex)))
+    assert_that("/pets/foo", not_(matches_regexp(as_regex)))
+
+
+def test_path_to_regex_with_multiple_params():
+    as_regex = path_to_regex(
+        '/pets/{id}/items/{name}', id={'type': 'number'}, name={'type': 'string'})
+
+    assert_that("/pets/32/items/car", as_regex)
+    assert_that("/pets/32/items/car", matches_regexp(as_regex))

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,13 @@
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 from http_types import HttpExchange, HttpExchangeBuilder
+from openapi_typed import OpenAPIObject
+from yaml import safe_load
+from meeshkan.schemabuilder.schema import validate_openapi_object
 
 SAMPLE_RECORDINGS_PATH = "resources/recordings.jsonl"
+PETSTORE_YAML_PATH = "resources/petstore.yaml"
+
 
 def read_recordings_as_strings(requests_path=SAMPLE_RECORDINGS_PATH) -> List[str]:
     with open(requests_path) as f:
@@ -15,3 +20,12 @@ def read_recordings_as_dict(requests_path=SAMPLE_RECORDINGS_PATH) -> List[Dict[A
 
 def read_recordings_as_request_response(requests_path=SAMPLE_RECORDINGS_PATH) -> List[HttpExchange]:
     return [HttpExchangeBuilder.from_dict(reqres) for reqres in read_recordings_as_dict(requests_path)]
+
+
+def petstore_schema() -> OpenAPIObject:
+    with open(PETSTORE_YAML_PATH, "r") as f:
+        oas = cast(Any, safe_load(f.read()))
+
+    validate_openapi_object(oas)
+
+    return oas


### PR DESCRIPTION
- Add `meeshkan.schemabuilder.paths` module for working with paths. For example, add code for matching path such as `/pets/{petId}` to `/pets/32`
- Add checks in `builder.py` for checking the path parameters are valid. This is mostly a sanity check for now, as the builder does not yet try to infer parameters from paths. This means that if request contains paths such as `/pets/1` and `/pets/2`, the builder doesn't yet try to combine them to `/pets/{id}`

Next steps:
- [ ]  Start adding logic for inferring which values in the path are parameters