### PR TITLE
Respect base path from schema servers field.

### DIFF
--- a/meeshkan/schemabuilder/servers.py
+++ b/meeshkan/schemabuilder/servers.py
@@ -1,0 +1,21 @@
+from openapi_typed import Server
+from http_types import Request
+from typing import List, Optional
+
+
+def normalize_path_if_matches(request: Request, servers: List[Server]) -> Optional[str]:
+    """Check if a request matches a list of server definitions.
+    If matches, return the normalized path.
+
+    For example: for server URL `https://petstore.swagger.io/v1` and request URL
+    `https://petstore.swagger.io/v1/pets`, return `/pets`.
+
+    Arguments:
+        servers {List[Server]} -- List of schema Server definitions.
+        request {Request} -- HTTP request.
+
+    Returns:
+        Optional[str] -- None if no match, normalized path if matches. 
+    """
+
+    return None

--- a/meeshkan/schemabuilder/servers.py
+++ b/meeshkan/schemabuilder/servers.py
@@ -1,6 +1,7 @@
 from openapi_typed import Server
 from http_types import Request
 from typing import List, Optional
+from urllib.parse import urlparse
 
 
 def normalize_path_if_matches(request: Request, servers: List[Server]) -> Optional[str]:
@@ -17,5 +18,18 @@ def normalize_path_if_matches(request: Request, servers: List[Server]) -> Option
     Returns:
         Optional[str] -- None if no match, normalized path if matches. 
     """
+
+    for server in servers:
+        server_url = urlparse(server['url'])
+        if server_url.scheme != request['protocol']:
+            continue
+
+        if server_url.netloc != request['host']:
+            continue
+
+        if not request['pathname'].startswith(server_url.path):
+            continue
+
+        return request['pathname'][len(server_url.path):]
 
     return None

--- a/meeshkan/schemabuilder/servers.py
+++ b/meeshkan/schemabuilder/servers.py
@@ -6,9 +6,9 @@ from urllib.parse import urlparse
 
 def normalize_path_if_matches(request: Request, servers: List[Server]) -> Optional[str]:
     """Check if a request matches a list of server definitions.
-    If matches, return the normalized path.
+    If matches, return the request path normalized by the server URL's basepath.
 
-    For example: for server URL `https://petstore.swagger.io/v1` and request URL
+    For example: for matching server URL `https://petstore.swagger.io/v1` and request URL
     `https://petstore.swagger.io/v1/pets`, return `/pets`.
 
     Arguments:
@@ -16,7 +16,7 @@ def normalize_path_if_matches(request: Request, servers: List[Server]) -> Option
         request {Request} -- HTTP request.
 
     Returns:
-        Optional[str] -- None if no match, normalized path if matches. 
+        Optional[str] -- None if request does not match any existing servers. Request path normalized by server basepath otherwise. 
     """
 
     for server in servers:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ REQUIRED = [
     'pyyaml',
     'jsonschema',
     'typing-extensions',
-    'openapi-typed',
+    'openapi-typed>=0.0.2',
     'typeguard>=2.7.0',
     'genson',
     'http-types>=0.0.4'

--- a/tests/schemabuilder/builder_test.py
+++ b/tests/schemabuilder/builder_test.py
@@ -103,9 +103,9 @@ class TestSchema:
 class TestPetstoreSchemaUpdate:
 
     get_pets_req = RequestBuilder.from_url(
-        "https://petstore.swagger.io/v1/pets")
+        "http://petstore.swagger.io/v1/pets")
     get_one_pet_req = RequestBuilder.from_url(
-        "https://petstore.swagger.io/v1/pets/32")
+        "http://petstore.swagger.io/v1/pets/32")
 
     res = Response(body="", statusCode=200, headers={})
 

--- a/tests/schemabuilder/servers_test.py
+++ b/tests/schemabuilder/servers_test.py
@@ -1,0 +1,23 @@
+from meeshkan.schemabuilder.servers import normalize_path_if_matches
+from openapi_typed import Server
+from typing import List
+from hamcrest import *
+
+from http_types import RequestBuilder
+
+petstore_req = RequestBuilder.from_url(
+    "https://petstore.swagger.io/v1/pets")
+
+petstore_server = Server(url="https://petstore.swagger.io/v1")
+
+
+def test_normalize_path_for_match():
+    norm_pathname = normalize_path_if_matches(petstore_req, [petstore_server])
+    assert_that(norm_pathname, is_("/pets"))
+
+
+def test_no_match():
+    req_no_match = RequestBuilder.from_url(
+        "https://petstore.swagger.io/v2/pets")
+    norm_pathname = normalize_path_if_matches(req_no_match, [petstore_server])
+    assert_that(norm_pathname, is_(None))


### PR DESCRIPTION
Closes #22.

- Normalize request path (e.g. /v1/pets) by the basepath in server URL (/v1). The result for the example is `/pets`.
- Does not construct a server URL for unknown server (#13)