### PR TITLE
Adopt to 'req' -> 'request' renaming in py-http-types

### DIFF
--- a/meeshkan/schemabuilder/builder.py
+++ b/meeshkan/schemabuilder/builder.py
@@ -271,7 +271,7 @@ def update_openapi(schema: OpenAPIObject, request: HttpExchange) -> OpenAPIObjec
         request['request'], schema_servers)
 
     if normalized_pathname_or_none is None:
-        schema_servers.append(Server(url=urlunsplit([request['req']['protocol'], request['req']['host'], '', '', ''])))
+        schema_servers.append(Server(url=urlunsplit([request['request']['protocol'], request['request']['host'], '', '', ''])))
         normalized_pathname = request_path
     else:
         normalized_pathname = normalized_pathname_or_none


### PR DESCRIPTION
The build of https://github.com/Meeshkan/meeshkan/pull/27 didn't detect that, as it doesn't test against the result of the merge, and the code in question was added after PR 27 was created.