### PR TITLE
Fix bug: non-json body raises an exception.

### DIFF
--- a/meeshkan/schemabuilder/builder.py
+++ b/meeshkan/schemabuilder/builder.py
@@ -1,104 +1,23 @@
 import copy
+from functools import reduce
 from urllib.parse import urlunsplit
 
 from http_types import HttpExchange as HttpExchange
-from ..logger import get as getLogger
-from functools import reduce
-from typing import Any, List, Iterator, cast, Tuple, Optional, Union, TypeVar, Type, Sequence
-from openapi_typed import Info, MediaType, OpenAPIObject, PathItem, Response, Operation, Schema, Parameter, Reference, \
+
+from typing import Any, List, Iterator, cast, Tuple, Optional, Union, TypeVar, Type
+from openapi_typed import Info, MediaType, OpenAPIObject, PathItem, Response, Operation, Parameter, Reference, \
     Server
 from typeguard import check_type  # type: ignore
-import json
-from typing_extensions import Literal
-from .json_schema import to_openapi_json_schema
-from .schema import validate_openapi_object
+
+from ..logger import get as getLogger
+from .media_types import infer_media_type_from_nonempty, build_media_type, update_media_type, MediaTypeKey
 from .paths import find_matching_path, RequestPathParameters
 from .query import build_query, update_query
+from .schema import validate_openapi_object
 from .servers import normalize_path_if_matches
 
+
 logger = getLogger(__name__)
-
-MediaTypeKey = Literal['application/json', 'text/plain']
-
-MEDIA_TYPE_FOR_NON_JSON = "text/plain"
-
-
-def infer_media_type_from_nonempty(body: str) -> MediaTypeKey:
-    """Determine media type (application/json, text/plain, etc.) from body.
-
-    Arguments:
-        body {str} -- Response body, should not be empty.
-
-    Raises:
-        Exception: If body is of unexpected type or empty.
-
-    Returns:
-        MediaTypeKey -- Media type such as "application/json"
-    """
-
-    if body == '':
-        raise Exception("Cannot infer media type from empty body.")
-
-    try:
-        as_json = json.loads(body)
-    except json.decoder.JSONDecodeError:
-        logger.debug(f"Failed decoding: {body}")
-        # TODO Handle application/xml etc.
-        return MEDIA_TYPE_FOR_NON_JSON
-
-    if isinstance(as_json, dict) or isinstance(as_json, list):
-        return 'application/json'
-    elif isinstance(as_json, str):
-        return 'text/plain'
-    else:
-        raise Exception(f"Not sure what to do with body: {body}")
-
-
-SchemaType = Literal['object', 'array', 'string']
-
-
-def update_json_schema(json_body: Any, schema: Optional[Any] = None) -> Schema:
-    # TODO typeguard
-    return cast(Schema, to_openapi_json_schema(json_body, schema))
-
-
-def update_text_schema(text_body: str, schema: Optional[Any] = None) -> Schema:
-    # TODO Better updates
-    return {"type": "string"}
-
-
-def update_media_type(exchange: HttpExchange, type_key: MediaTypeKey, media_type: Optional[MediaType] = None) -> MediaType:
-    """Update media type.
-
-    Arguments:
-        exchange {HttpExchange} -- Http exchange
-        type_key {MediaTypeKey} -- MediaType such as "application/json"
-
-    Keyword Arguments:
-        media_type {Optional[MediaType]} -- Existing media type if exists. For example, "{ 'schema': { 'type': 'string' }}"
-
-    Raises:
-        Exception: If existing media type is unknown.
-
-    Returns:
-        MediaType -- Updated media type object.
-    """
-    body = exchange['response']['body']
-
-    existing_schema = (media_type or {}).get("schema", None)
-
-    if type_key == "application/json":
-        schema = update_json_schema(json.loads(body), schema=existing_schema)
-    elif type_key == "text/plain":
-        schema = update_text_schema(body, schema=existing_schema)
-    else:
-        raise Exception("Unknown type key")
-    media_type = MediaType(schema=schema)
-    return media_type
-
-
-def build_media_type(exchange: HttpExchange, type_key: MediaTypeKey) -> MediaType:
-    return update_media_type(exchange=exchange, type_key=type_key, media_type=None)
 
 
 def build_response_content(exchange: HttpExchange) -> Optional[Tuple[MediaTypeKey, MediaType]]:

--- a/meeshkan/schemabuilder/builder.py
+++ b/meeshkan/schemabuilder/builder.py
@@ -43,6 +43,7 @@ def infer_media_type_from_nonempty(body: str) -> MediaTypeKey:
         as_json = json.loads(body)
     except json.decoder.JSONDecodeError:
         logger.debug(f"Failed decoding: {body}")
+        # TODO Handle application/xml etc.
         return MEDIA_TYPE_FOR_NON_JSON
 
     if isinstance(as_json, dict) or isinstance(as_json, list):

--- a/meeshkan/schemabuilder/media_types.py
+++ b/meeshkan/schemabuilder/media_types.py
@@ -1,0 +1,91 @@
+
+"""Code for building and inferring media types (application/json, text/plain, etc.) from HTTP exchanges."""
+from http_types import HttpExchange as HttpExchange
+from ..logger import get as getLogger
+from typing import Any, cast, Optional
+from openapi_typed import MediaType, Schema
+import json
+from typing_extensions import Literal
+from .json_schema import to_openapi_json_schema
+
+
+logger = getLogger(__name__)
+
+MediaTypeKey = Literal['application/json', 'text/plain']
+
+MEDIA_TYPE_FOR_NON_JSON = "text/plain"
+
+
+def update_json_schema(json_body: Any, schema: Optional[Any] = None) -> Schema:
+    # TODO typeguard
+    return cast(Schema, to_openapi_json_schema(json_body, schema))
+
+
+def update_text_schema(text_body: str, schema: Optional[Any] = None) -> Schema:
+    # TODO Better updates
+    return {"type": "string"}
+
+
+def infer_media_type_from_nonempty(body: str) -> MediaTypeKey:
+    """Determine media type (application/json, text/plain, etc.) from body.
+
+    Arguments:
+        body {str} -- Response body, should not be empty.
+
+    Raises:
+        Exception: If body is of unexpected type or empty.
+
+    Returns:
+        MediaTypeKey -- Media type such as "application/json"
+    """
+
+    if body == '':
+        raise Exception("Cannot infer media type from empty body.")
+
+    try:
+        as_json = json.loads(body)
+    except json.decoder.JSONDecodeError:
+        logger.debug(f"Failed decoding: {body}")
+        # TODO Handle application/xml etc.
+        return MEDIA_TYPE_FOR_NON_JSON
+
+    if isinstance(as_json, dict) or isinstance(as_json, list):
+        return 'application/json'
+    elif isinstance(as_json, str):
+        return 'text/plain'
+    else:
+        raise Exception(f"Not sure what to do with body: {body}")
+
+
+def update_media_type(exchange: HttpExchange, type_key: MediaTypeKey, media_type: Optional[MediaType] = None) -> MediaType:
+    """Update media type.
+
+    Arguments:
+        exchange {HttpExchange} -- Http exchange
+        type_key {MediaTypeKey} -- MediaType such as "application/json"
+
+    Keyword Arguments:
+        media_type {Optional[MediaType]} -- Existing media type if exists. For example, "{ 'schema': { 'type': 'string' }}"
+
+    Raises:
+        Exception: If existing media type is unknown.
+
+    Returns:
+        MediaType -- Updated media type object.
+    """
+    body = exchange['response']['body']
+
+    existing_schema = (media_type or {}).get("schema", None)
+
+    if type_key == "application/json":
+        schema = update_json_schema(json.loads(body), schema=existing_schema)
+    elif type_key == "text/plain":
+        schema = update_text_schema(body, schema=existing_schema)
+    else:
+        raise Exception("Unknown type key")
+    media_type = MediaType(schema=schema)
+    return media_type
+
+
+def build_media_type(exchange: HttpExchange, type_key: MediaTypeKey) -> MediaType:
+    return update_media_type(exchange=exchange, type_key=type_key, media_type=None)

--- a/tests/schemabuilder/builder_test.py
+++ b/tests/schemabuilder/builder_test.py
@@ -187,5 +187,11 @@ class TestSchemaTextBody:
 
     def test_build_string_body(self):
         schema = build_schema_batch([self.exchange])
-        op = schema['paths']['/v1']['get'][200]
-        assert op is not None  # TODO Better test
+        response_content = schema['paths']['/v1']['get']['responses']['200']['content']
+
+        assert_that(response_content, has_key("text/plain"))
+
+        media_type = response_content["text/plain"]
+
+        assert_that(media_type, has_entry(
+            "schema", has_entry("type", "string")))

--- a/tests/schemabuilder/builder_test.py
+++ b/tests/schemabuilder/builder_test.py
@@ -99,7 +99,6 @@ class TestSchema:
         assert_that(properties, has_entry('clone_url',
                                           equal_to({'type': 'string'})))
 
-
     def test_servers(self):
         servers = self.schema['servers']
         assert 1 == len(servers)
@@ -179,3 +178,14 @@ class TestQueryParameters:
         first_query_param = operation['parameters'][0]
 
         assert_that(first_query_param, has_entry("required", False))
+
+
+class TestSchemaTextBody:
+    request = RequestBuilder.from_url("https://example.com/v1")
+    response = Response(statusCode=200, body="Hello World", headers={})
+    exchange: HttpExchange = {'request': request, 'response': response}
+
+    def test_build_string_body(self):
+        schema = build_schema_batch([self.exchange])
+        op = schema['paths']['/v1']['get'][200]
+        assert op is not None  # TODO Better test


### PR DESCRIPTION
- Fix bug where a non-json text body such as "Hello" raised an exception instead of setting the schema as `{type: "string" }`
- Add new `media_types.py` module for all code related to building media types from bodies