### PR TITLE
Open api scaffolding

### DIFF
--- a/meeshkan/schemabuilder/builder.py
+++ b/meeshkan/schemabuilder/builder.py
@@ -298,8 +298,8 @@ BASE_SCHEMA = OpenAPIObject(openapi="3.0.0",
                             paths={})
 
 
-async def build_schema_async(async_iter: AsyncIterable[HttpExchange]) -> AsyncIterable[BuildResult]:
-    schema = BASE_SCHEMA
+async def build_schema_async(async_iter: AsyncIterable[HttpExchange], initial_open_api_spec: OpenAPIObject) -> AsyncIterable[BuildResult]:
+    schema = initial_open_api_spec
     async for exchange in async_iter:
         schema = update_openapi(schema, exchange)
         yield BuildResult(openapi=schema)

--- a/meeshkan/schemabuilder/schema.py
+++ b/meeshkan/schemabuilder/schema.py
@@ -21,4 +21,4 @@ def _openapi_json_schema():
 
 
 def validate_openapi_object(instance: OpenAPIObject):
-    return validate(instance=instance, schema=_openapi_json_schema())
+    validate(instance=instance, schema=_openapi_json_schema())

--- a/meeshkan/sources/__init__.py
+++ b/meeshkan/sources/__init__.py
@@ -1,3 +1,4 @@
 from .kafka import KafkaSource
 from .abstract import AbstractSource
 from .file import FileSource
+from .folder import FolderSource

--- a/meeshkan/sources/abstract.py
+++ b/meeshkan/sources/abstract.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 from typing import Tuple, Optional
 from ..types import HttpExchangeStream
+from openapi_typed import OpenAPIObject
 
 
 class AbstractSource(abc.ABC):
@@ -23,5 +24,11 @@ class AbstractSource(abc.ABC):
     @abc.abstractmethod
     def shutdown(self) -> None:
         """Shutdown source.
+        """
+        raise NotImplementedError("")
+
+    @abc.abstractmethod
+    def initial_openapi_spec(self) -> OpenAPIObject:
+        """An initial OpenAPI spec to build off of
         """
         raise NotImplementedError("")

--- a/meeshkan/sources/file.py
+++ b/meeshkan/sources/file.py
@@ -3,6 +3,8 @@ from http_types.types import HttpExchange
 from http_types.utils import HttpExchangeReader
 from .abstract import AbstractSource
 import asyncio
+from ..schemabuilder.builder import BASE_SCHEMA
+
 
 
 class FileSource(AbstractSource):
@@ -21,3 +23,6 @@ class FileSource(AbstractSource):
 
     def shutdown(self):
         pass
+
+    def initial_openapi_spec(self):
+        return BASE_SCHEMA

--- a/meeshkan/sources/folder.py
+++ b/meeshkan/sources/folder.py
@@ -1,0 +1,39 @@
+from typing import AsyncIterable, Tuple, cast
+from http_types.types import HttpExchange
+from http_types.utils import HttpExchangeReader
+from .abstract import AbstractSource
+from ..schemabuilder.schema import validate_openapi_object
+from ..schemabuilder.builder import BASE_SCHEMA
+from yaml import safe_load
+import os
+import asyncio
+from openapi_typed import OpenAPIObject
+
+class FolderSource(AbstractSource):
+
+    def __init__(self, input_folder: str):
+        self.input_folder = input_folder
+
+    async def start(self, loop: asyncio.events.AbstractEventLoop) -> Tuple[AsyncIterable[HttpExchange], None]:
+        # print(self.input_folder)
+
+        async def read():
+            for line in self.input_folder:
+                yield HttpExchangeReader.from_json(line)
+
+        return read(), None
+
+    def shutdown(self):
+        pass
+
+    def initial_openapi_spec(self) -> OpenAPIObject:
+        for f in os.listdir(self.input_folder):
+            try:
+                with open(os.path.join(self.input_folder, f)) as infile:
+                    maybe_openapi = safe_load(infile.read())
+                    # will raise if not an API spec
+                    validate_openapi_object(maybe_openapi)
+                    return cast(OpenAPIObject, maybe_openapi)
+            except:
+                continue
+        return BASE_SCHEMA

--- a/meeshkan/sources/folder.py
+++ b/meeshkan/sources/folder.py
@@ -18,8 +18,11 @@ class FolderSource(AbstractSource):
         # print(self.input_folder)
 
         async def read():
-            for line in self.input_folder:
-                yield HttpExchangeReader.from_json(line)
+            for f in os.listdir(self.input_folder):
+                if f[-6:] == '.jsonl':
+                    with open(os.path.join(self.input_folder, f)) as infile:
+                        for line in infile:
+                            yield HttpExchangeReader.from_json(line)
 
         return read(), None
 

--- a/meeshkan/sources/folder.py
+++ b/meeshkan/sources/folder.py
@@ -33,10 +33,10 @@ class FolderSource(AbstractSource):
         for f in os.listdir(self.input_folder):
             try:
                 with open(os.path.join(self.input_folder, f)) as infile:
-                    maybe_openapi = safe_load(infile.read())
+                    maybe_openapi = cast(OpenAPIObject, safe_load(infile.read()))
                     # will raise if not an API spec
                     validate_openapi_object(maybe_openapi)
-                    return cast(OpenAPIObject, maybe_openapi)
+                    return maybe_openapi
             except:
                 continue
         return BASE_SCHEMA

--- a/meeshkan/sources/folder.py
+++ b/meeshkan/sources/folder.py
@@ -19,7 +19,7 @@ class FolderSource(AbstractSource):
 
         async def read():
             for f in os.listdir(self.input_folder):
-                if f[-6:] == '.jsonl':
+                if f.endswith('.jsonl'):
                     with open(os.path.join(self.input_folder, f)) as infile:
                         for line in infile:
                             yield HttpExchangeReader.from_json(line)

--- a/meeshkan/sources/kafka.py
+++ b/meeshkan/sources/kafka.py
@@ -9,6 +9,7 @@ try:
     import faust
 except ImportError:
     faust = None
+from ..schemabuilder.builder import BASE_SCHEMA
 
 
 class KafkaProcessorConfig:
@@ -81,6 +82,9 @@ class KafkaSource(AbstractSource):
     def shutdown(self):
         self.worker_task.cancel()
         self.worker.stop_and_shutdown()
+
+    def initial_openapi_spec(self):
+        return BASE_SCHEMA
 
 
 __all__ = ["KafkaProcessorConfig", "KafkaProcessor", "KafkaSource"]

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -33,7 +33,7 @@ def test_build_cmd():
         ), "Output directory {} should not exist yet".format(output_directory)
 
         runner_result = runner.invoke(
-            cli, ['build', '-i', input_file, '-o', output_directory, '--source', 'file'])
+            cli, ['build', '-i', input_file, '-o', output_directory])
 
         assert output_directory_path.is_dir(
         ), "Output directory {} should exist".format(output_directory)


### PR DESCRIPTION
Adds a `-f` option to read from a folder, consuming an initial OpenAPI spec if present and multiple `jsonl` files if present.