### PR TITLE
Add mypy.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /out/
 /build/
 /dist/
+/.mypy_cache/

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,11 @@
+# https://mypy.readthedocs.io/en/latest/config_file.html
+
+# Global options:
+
+[mypy]
+python_version = 3.7
+warn_return_any = False
+warn_unused_configs = True
+ignore_missing_imports = True
+files = meeshkan,tests
+# follow_imports = error

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ BUILD_COMMAND = "{executable} setup.py sdist bdist_wheel --universal".format(
     executable=sys.executable
 )
 
-TYPE_CHECK_COMMAND = "mypy"
+TYPE_CHECK_COMMAND = "pyright --lib"
 
 TEST_COMMAND = "pytest"
 

--- a/setup.py
+++ b/setup.py
@@ -18,35 +18,35 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = "\n" + f.read()
 
 REQUIRED = [
-    'click==7.0',
-    'lenses',
-    'pyyaml',
-    'jsonschema',
-    'dataclasses', # for 3.6, as it ships with 3.7
-    'faker',
-    'requests',
-    'typing-extensions',
-    'openapi-typed_2>=0.0.2',
-    'typeguard>=2.7.0',
-    'genson',
-    'http-types>=0.0.13,<0.1.0',
+    "click==7.0",
+    "lenses",
+    "pyyaml",
+    "jsonschema",
+    "dataclasses",  # for 3.6, as it ships with 3.7
+    "faker",
+    "requests",
+    "typing-extensions",
+    "openapi-typed_2>=0.0.2",
+    "typeguard>=2.7.0",
+    "genson",
+    "http-types>=0.0.13,<0.1.0",
     # kafka
-    'faust',
+    "faust",
     # mock
-    'tornado==5.1.1',
-    'urllib3==1.25.6',
-    'daemonocle'
+    "tornado==5.1.1",
+    "urllib3==1.25.6",
+    "daemonocle",
 ]
 
 BUNDLES = {}
 
 # Requirements of all bundles
-BUNDLE_REQUIREMENTS = [dep for _, bundle_dep in BUNDLES.items()
-                       for dep in bundle_dep]
+BUNDLE_REQUIREMENTS = [dep for _, bundle_dep in BUNDLES.items() for dep in bundle_dep]
 
 DEV = BUNDLE_REQUIREMENTS + [
     "black==19.10b0",
     "flake8",
+    "mypy",
     "pyhamcrest",
     "pylint",
     "pytest",
@@ -60,7 +60,7 @@ DEV = BUNDLE_REQUIREMENTS + [
     "wheel",
 ]
 
-VERSION = '0.2.16'
+VERSION = "0.2.16"
 
 ENTRY_POINTS = ["meeshkan = meeshkan.__main__:cli"]
 
@@ -104,9 +104,10 @@ class SetupCommand(Command):
 
 
 BUILD_COMMAND = "{executable} setup.py sdist bdist_wheel --universal".format(
-    executable=sys.executable)
+    executable=sys.executable
+)
 
-TYPE_CHECK_COMMAND = "pyright --lib"
+TYPE_CHECK_COMMAND = "mypy"
 
 TEST_COMMAND = "pytest"
 


### PR DESCRIPTION
Alternative, more established [typechecker](https://mypy.readthedocs.io/en/stable/) that could provide better typing experience than pyright.
- [ ]  Editor support? Pyright works very well for me in VS Code, whereas the [mypy linting](https://code.visualstudio.com/docs/python/linting#_specific-linters) shipping with vscode python extension behaves really weird and flags totally wrong lines. PyCharm should work fine.
