### PR TITLE
Allow server in openapi spec without protocol to pass if host matches

### DIFF
--- a/meeshkan/gen/generator.py
+++ b/meeshkan/gen/generator.py
@@ -164,7 +164,7 @@ def match_urls(protocol: str, host: str, o: OpenAPIObject) -> Sequence[str]:
     return [server.url
         for server in servers
         if ((urlparse(server.url).scheme in ['', None]) or (urlparse(server.url).scheme == protocol))
-            and ((server.url == host) or (urlparse(server.url).netloc == host))]
+            and ((server.url.split('/')[0] == host) or (urlparse(server.url).netloc == host))]
 
 def get_component_from_ref(o: OpenAPIObject, d: str, accessor: Callable[[Components], Optional[Mapping[str, Union[Reference, C]]]], getter: Callable[[OpenAPIObject, Union[C, Reference]], Optional[C]]) -> Optional[C]:
     return lens.F(

--- a/meeshkan/gen/generator.py
+++ b/meeshkan/gen/generator.py
@@ -157,10 +157,14 @@ def match_urls(protocol: str, host: str, o: OpenAPIObject) -> Sequence[str]:
     servers = o.servers
     if servers is None:
         return []
+    #### if the openapi server url has no scheme,
+    #### we ignore the incoming scheme and treat the url as the host
+    #### not sure if this is the right decision,
+    #### but it deals with a realistic outcome in certain schemas
     return [server.url
         for server in servers
-        if (urlparse(server.url).scheme == protocol)
-            and  (urlparse(server.url).netloc == host)]
+        if ((urlparse(server.url).scheme in ['', None]) or (urlparse(server.url).scheme == protocol))
+            and ((server.url == host) or (urlparse(server.url).netloc == host))]
 
 def get_component_from_ref(o: OpenAPIObject, d: str, accessor: Callable[[Components], Optional[Mapping[str, Union[Reference, C]]]], getter: Callable[[OpenAPIObject, Union[C, Reference]], Optional[C]]) -> Optional[C]:
     return lens.F(

--- a/tests/generator/matcher_test.py
+++ b/tests/generator/matcher_test.py
@@ -7,7 +7,7 @@ import json
 store: Dict[str, OpenAPIObject] = {
   'foo': convert_to_openapi({
     'openapi': "",
-    'servers': [{ 'url': "https://api.foo.com" }],
+    'servers': [{ 'url': "api.foo.com" }], # we omit the protocol and it should still match
     'info': { 'title': "", 'version': "" },
     'paths': {
       "/user": {
@@ -38,7 +38,7 @@ store: Dict[str, OpenAPIObject] = {
   }),
   'bar': convert_to_openapi({
     'openapi': "",
-    'servers': [{ 'url': "https://api.bar.com" }],
+    'servers': [{ 'url': "https://api.bar.com/v1" }],
     'info': { 'title': "", 'version': "" },
     'paths': {
       "/guest": {
@@ -168,7 +168,7 @@ def test_matcher_1():
     ) == {
     'foo': convert_to_openapi({
       'openapi': "",
-      'servers': [{ 'url': "https://api.foo.com" }],
+      'servers': [{ 'url': "api.foo.com" }],
       'info': { 'title': "", 'version': "" },
       'paths': {
         "/user": {
@@ -184,8 +184,8 @@ def test_matcher_2():
       RequestBuilder.from_dict({
         'headers': {},
         'host': "api.bar.com",
-        'path': "/guest/{id}",
-        'pathname': "/guest/{id}",
+        'path': "/v1/guest/{id}",
+        'pathname': "/v1/guest/{id}",
         'protocol': "https",
         'method': "post",
         'query': {},
@@ -194,7 +194,7 @@ def test_matcher_2():
     ) == {
         'bar': convert_to_openapi({
             'openapi': "",
-            'servers': [{ 'url': "https://api.bar.com" }],
+            'servers': [{ 'url': "https://api.bar.com/v1" }],
             'info': { 'title': "", 'version': "" },
             'paths': {
                 "/guest/{id}": {
@@ -220,7 +220,7 @@ def test_matcher_3():
     ) == {
     'foo': convert_to_openapi({
       'openapi': "",
-      'servers': [{ 'url': "https://api.foo.com" }],
+      'servers': [{ 'url': "api.foo.com" }],
       'info': { 'title': "", 'version': "" },
       'paths': {},
     })
@@ -241,7 +241,7 @@ def test_matcher_4():
     ) == {
     'foo': convert_to_openapi({
       'openapi': "",
-      'servers': [{ 'url': "https://api.foo.com" }],
+      'servers': [{ 'url': "api.foo.com" }],
       'info': { 'title': "", 'version': "" },
       'paths': {
         "/user/{id}": {
@@ -276,7 +276,7 @@ def test_matcher_5():
     ) == {
     'foo': convert_to_openapi({
       'openapi': "",
-      'servers': [{ 'url': "https://api.foo.com" }],
+      'servers': [{ 'url': "api.foo.com" }],
       'info': { 'title': "", 'version': "" },
       'paths': {},
     }),
@@ -297,7 +297,7 @@ def test_matcher_6():
     ) == {
     'foo': convert_to_openapi({
       'openapi': "",
-      'servers': [{ 'url': "https://api.foo.com" }],
+      'servers': [{ 'url': "api.foo.com" }],
       'info': { 'title': "", 'version': "" },
       'paths': {
         "/user": {


### PR DESCRIPTION
This is necessary when the protocol is not available.