### PR TITLE
Add formatting and style-checks.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,14 +51,14 @@ jobs: # A basic unit of work in a run
             yarn global add pyright
             export VENV_HOME_DIR=$(pipenv --venv)
             source $VENV_HOME_DIR/bin/activate
-            pyright --lib
+            python setup.py test
       - run:
           name: Run integretion tests
           command: |
             export VENV_HOME_DIR=$(pipenv --venv)
             source $VENV_HOME_DIR/bin/activate
             git clone https://github.com/meeshkan/meeshkan-examples.git  ../meeshkan-examples
-            cd ../meeshkan-examples &&  python run_all.py
+            cd ../meeshkan-examples && python run_all.py
   test-3.7:
     <<: *test-template
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,6 @@ jobs: # A basic unit of work in a run
       - run:
           name: Run integretion tests
           command: |
-            export VENV_HOME_DIR=$(pipenv --venv)
-            source $VENV_HOME_DIR/bin/activate
             git clone https://github.com/meeshkan/meeshkan-examples.git  ../meeshkan-examples
             cd ../meeshkan-examples && python run_all.py
   test-3.7:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,7 @@ jobs: # A basic unit of work in a run
             echo 'export VENV_HOME_DIR=$(pipenv --venv)' >> $BASH_ENV
             echo 'source $VENV_HOME_DIR/bin/activate' >> $BASH_ENV
       - run:
-          name: Run pytest
-          command: |
-            pytest -s
-      - run:
-          name: Install pyright and run typecheck
+          name: Install pyright and run all checks
           command: |
             set +e
             echo 'export PATH=$(yarn global bin):$PATH' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs: # A basic unit of work in a run
           name: Install pipenv
           command: |
             sudo pip install pipenv
-            pipenv install --pre black
             pipenv install -e .[dev]
             pipenv update
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,11 @@ jobs: # A basic unit of work in a run
             sudo pip install pipenv
             pipenv install -e .[dev]
             pipenv update
+            echo 'export VENV_HOME_DIR=$(pipenv --venv)' >> $BASH_ENV
+            echo 'source $VENV_HOME_DIR/bin/activate' >> $BASH_ENV
       - run:
           name: Run pytest
           command: |
-            export VENV_HOME_DIR=$(pipenv --venv)
-            source $VENV_HOME_DIR/bin/activate
             pytest -s
       - run:
           name: Install pyright and run typecheck
@@ -49,8 +49,6 @@ jobs: # A basic unit of work in a run
             echo 'export PATH=$(yarn global bin):$PATH' >> $BASH_ENV
             source $BASH_ENV
             yarn global add pyright
-            export VENV_HOME_DIR=$(pipenv --venv)
-            source $VENV_HOME_DIR/bin/activate
             python setup.py test
       - run:
           name: Run integretion tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,8 +7,7 @@ workflows:
       - test-3.7
       - test-3.8
 jobs: # A basic unit of work in a run
-  test-3.6: &test-template
-    # directory where steps are run
+  test-3.6: &test-template # directory where steps are run
     working_directory: ~/meeshkan
     docker: # run the steps with Docker
       # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
@@ -35,6 +34,7 @@ jobs: # A basic unit of work in a run
           name: Install pipenv
           command: |
             sudo pip install pipenv
+            pipenv install --pre black
             pipenv install -e .[dev]
             pipenv update
       - run:

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,12 @@
+[flake8]
+include = meeshkan,tests
+ignore = E203, E266, E501, W503
+# line length is intentionally set to 80 here because black uses Bugbear
+# See https://github.com/psf/black/blob/master/README.md#line-length for more details
+max-line-length = 80
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+# We need to configure the mypy.ini because the flake8-mypy's default
+# options don't properly override it, so if we don't specify it we get
+# half of the config from mypy.ini and half from flake8-mypy.
+mypy_config = mypy.ini

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-include = meeshkan,tests
+exclude = .git,.venv,__pycache__,build,dist
 ignore = E203, E266, E501, W503
 # line length is intentionally set to 80 here because black uses Bugbear
 # See https://github.com/psf/black/blob/master/README.md#line-length for more details

--- a/README.md
+++ b/README.md
@@ -71,12 +71,26 @@ Once you've run this, you should see:
  / / / / / /  __/  __(__  ) / / / ,< / /_/ / / / /
 /_/ /_/ /_/\___/\___/____/_/ /_/_/|_|\__,_/_/ /_/
 
+<<<<<<< HEAD
+=======
+### Building modes
+
+You can use a mode flag to indicate how the OpenAPI spec should be built, ie:
+>>>>>>> 852eeb2... Update README.
 
 The tutorial!!
 Press ENTER to continue...
 ```
 
+<<<<<<< HEAD
 If not, it's probably our fault. Please let us know by [filing an issue on the meeshkan-tutorial repo](https://github.com/meeshkan/meeshkan-tutorial/issues).
+=======
+Supported modes are:
+
+- gen [default] - infer a schema from the recorded data
+- replay - replay the recorded data based on exact matching
+- mixed - replay the recorded data based on exact matching when it is possible
+>>>>>>> 852eeb2... Update README.
 
 ## Collect recordings of API traffic
 
@@ -97,7 +111,16 @@ $ curl http://localhost:8000/http://api.example.com
 
 By default, the recording proxy treats the path as the target URL and writes a [`.jsonl`](https://jsonlines.org) file containing logs of all server traffic to a `logs` directory.  All logs are created in the [`http-types`](https://github.com/meeshkan/http-types) format.  The `meeshkan build` tool expects all recordings to be represented in a `.jsonl` file containing recordings represented in the `http-types` format.
 
+<<<<<<< HEAD
 For more information about recording, including direct file writing and kafka streaming, see the [recording documentation](./docs/RECORD.md).
+=======
+| Argument     | Description                                                                                                            | Default |
+| ------------ | ---------------------------------------------------------------------------------------------------------------------- | ------- |
+| `port`       | Server port                                                                                                            | 8000    |
+| `admin_port` | Admin port                                                                                                             | 8999    |
+| `log_dir`    | The directory containing `.jsonl` files for mocking directly from recorded fixtures                                    | `logs`  |
+| `specs_dir`  | The directory containing `.yml` or `.yaml` OpenAPI specs used for mocking, including ones built using `meeshkan build` | `specs` |
+>>>>>>> 852eeb2... Update README.
 
 ## Build a Meeshkan spec from recordings
 
@@ -108,17 +131,27 @@ $ pip install meeshkan # if not done yet
 $ meeshkan build -i path/to/recordings.jsonl [-o path/to/output_directory]
 ```
 
+<<<<<<< HEAD
 The input file should be in [JSON Lines](http://jsonlines.org/) format and every line should be in [http-types](https://meeshkan.github.io/http-types/) JSON format. 
 
 For an example input file, see [recordings.jsonl](https://github.com/Meeshkan/meeshkan/blob/master/resources/recordings.jsonl). The libraries listed at [http-types](https://meeshkan.github.io/http-types/) can be used to generate input files in your language of choice.
 
 Use dash (`-i -`) to read from standard input:
+=======
+This starts Meeshkan as a reverse proxy on the default port of `8000`. For example, with curl, you can use Meeshkan as a proxy like so.
+>>>>>>> 852eeb2... Update README.
 
 ```bash
 $ meeshkan build -i - < recordings.jsonl
 ```
+<<<<<<< HEAD
 ### Building modes
 You can use a mode flag to indicate how the OpenAPI spec should be built, for example:
+=======
+
+By default the recording proxy uses the first path items to navigate to a target host.
+Now you should have the `logs` folder with jsonl files and the `__unmock__` folder with ready openapi schemes.
+>>>>>>> 852eeb2... Update README.
 
 ```bash
 meeshkan build -i path/to/recordings.jsonl --mode gen
@@ -153,7 +186,19 @@ Here are some useful tips for building and running Meeshkan from source.
 
 ### Tests
 
+<<<<<<< HEAD
 You can run the  [tests/](https://github.com/Meeshkan/meeshkan/tree/master/tests/) with `pytest`:
+=======
+Run all checks:
+
+```bash
+$ python setup.py test
+```
+
+#### `pytest`
+
+Run [tests/](https://github.com/Meeshkan/meeshkan/tree/master/tests/) with `pytest`:
+>>>>>>> 852eeb2... Update README.
 
 ```bash
 pytest
@@ -163,7 +208,29 @@ python setup.py test
 
 Configuration for `pytest` is found in [pytest.ini](https://github.com/Meeshkan/meeshkan/tree/master/pytest.ini).
 
-### Type-checking
+#### `black`
+
+Run format checks:
+
+```bash
+$ black --check .
+```
+
+Fix formatting:
+
+```bash
+$ black .
+```
+
+#### `flake8`
+
+Run style checks:
+
+```bash
+$ flake8 .
+```
+
+#### `pyright`
 
 You can run type-checking by installing [pyright](https://github.com/microsoft/pyright) globally:
 

--- a/README.md
+++ b/README.md
@@ -71,26 +71,12 @@ Once you've run this, you should see:
  / / / / / /  __/  __(__  ) / / / ,< / /_/ / / / /
 /_/ /_/ /_/\___/\___/____/_/ /_/_/|_|\__,_/_/ /_/
 
-<<<<<<< HEAD
-=======
-### Building modes
-
-You can use a mode flag to indicate how the OpenAPI spec should be built, ie:
->>>>>>> 852eeb2... Update README.
 
 The tutorial!!
 Press ENTER to continue...
 ```
 
-<<<<<<< HEAD
 If not, it's probably our fault. Please let us know by [filing an issue on the meeshkan-tutorial repo](https://github.com/meeshkan/meeshkan-tutorial/issues).
-=======
-Supported modes are:
-
-- gen [default] - infer a schema from the recorded data
-- replay - replay the recorded data based on exact matching
-- mixed - replay the recorded data based on exact matching when it is possible
->>>>>>> 852eeb2... Update README.
 
 ## Collect recordings of API traffic
 
@@ -111,16 +97,7 @@ $ curl http://localhost:8000/http://api.example.com
 
 By default, the recording proxy treats the path as the target URL and writes a [`.jsonl`](https://jsonlines.org) file containing logs of all server traffic to a `logs` directory.  All logs are created in the [`http-types`](https://github.com/meeshkan/http-types) format.  The `meeshkan build` tool expects all recordings to be represented in a `.jsonl` file containing recordings represented in the `http-types` format.
 
-<<<<<<< HEAD
 For more information about recording, including direct file writing and kafka streaming, see the [recording documentation](./docs/RECORD.md).
-=======
-| Argument     | Description                                                                                                            | Default |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------- | ------- |
-| `port`       | Server port                                                                                                            | 8000    |
-| `admin_port` | Admin port                                                                                                             | 8999    |
-| `log_dir`    | The directory containing `.jsonl` files for mocking directly from recorded fixtures                                    | `logs`  |
-| `specs_dir`  | The directory containing `.yml` or `.yaml` OpenAPI specs used for mocking, including ones built using `meeshkan build` | `specs` |
->>>>>>> 852eeb2... Update README.
 
 ## Build a Meeshkan spec from recordings
 
@@ -131,27 +108,17 @@ $ pip install meeshkan # if not done yet
 $ meeshkan build -i path/to/recordings.jsonl [-o path/to/output_directory]
 ```
 
-<<<<<<< HEAD
 The input file should be in [JSON Lines](http://jsonlines.org/) format and every line should be in [http-types](https://meeshkan.github.io/http-types/) JSON format. 
 
 For an example input file, see [recordings.jsonl](https://github.com/Meeshkan/meeshkan/blob/master/resources/recordings.jsonl). The libraries listed at [http-types](https://meeshkan.github.io/http-types/) can be used to generate input files in your language of choice.
 
 Use dash (`-i -`) to read from standard input:
-=======
-This starts Meeshkan as a reverse proxy on the default port of `8000`. For example, with curl, you can use Meeshkan as a proxy like so.
->>>>>>> 852eeb2... Update README.
 
 ```bash
 $ meeshkan build -i - < recordings.jsonl
 ```
-<<<<<<< HEAD
 ### Building modes
 You can use a mode flag to indicate how the OpenAPI spec should be built, for example:
-=======
-
-By default the recording proxy uses the first path items to navigate to a target host.
-Now you should have the `logs` folder with jsonl files and the `__unmock__` folder with ready openapi schemes.
->>>>>>> 852eeb2... Update README.
 
 ```bash
 meeshkan build -i path/to/recordings.jsonl --mode gen
@@ -186,9 +153,6 @@ Here are some useful tips for building and running Meeshkan from source.
 
 ### Tests
 
-<<<<<<< HEAD
-You can run the  [tests/](https://github.com/Meeshkan/meeshkan/tree/master/tests/) with `pytest`:
-=======
 Run all checks:
 
 ```bash
@@ -198,7 +162,6 @@ $ python setup.py test
 #### `pytest`
 
 Run [tests/](https://github.com/Meeshkan/meeshkan/tree/master/tests/) with `pytest`:
->>>>>>> 852eeb2... Update README.
 
 ```bash
 pytest

--- a/setup.py
+++ b/setup.py
@@ -128,12 +128,12 @@ def run_tests():
     run_sys_command(TEST_COMMAND, "Tests failed")
 
 
-def lint():
-    run_sys_command(LINT_COMMAND, "Linting failed")
+def check_style():
+    run_sys_command(LINT_COMMAND, "CHecking style failed")
 
 
-def run_formatting():
-    run_sys_command(FORMAT_COMMAND, "Formatting failed")
+def check_formatting():
+    run_sys_command(FORMAT_CHECK_COMMAND, "Checking formatting failed")
 
 
 class BuildDistCommand(SetupCommand):
@@ -163,13 +163,13 @@ class TestCommand(SetupCommand):
     description = "Run tests, formatting, type-checks, and linting"
 
     def run(self):
-        self.status("Formatting code with black...")
-        run_formatting()
+        self.status("Checking formatting...")
+        check_formatting()
 
-        self.status("Running flake8...")
-        lint()
+        self.status("Checking style...")
+        check_style()
 
-        self.status("Running type-checking...")
+        self.status("Checking types...")
         type_check()
 
         self.status("Running pytest...")
@@ -227,6 +227,4 @@ setup(
         "test": TestCommand,
         "typecheck": TypeCheckCommand,
     },
-
-
 )

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = "\n" + f.read()
 
 REQUIRED = [
-<<<<<<< HEAD
     'click==7.0',
     'lenses',
     'pyyaml',
@@ -37,25 +36,6 @@ REQUIRED = [
     'tornado==5.1.1',
     'urllib3==1.25.6',
     'daemonocle'
-=======
-    "click",
-    "lenses",
-    "pyyaml",
-    "jsonschema",
-    "dataclasses",  # for 3.6, as it ships with 3.7
-    "faker",
-    "requests",
-    "typing-extensions",
-    "openapi-typed_2>=0.0.2",
-    "typeguard>=2.7.0",
-    "genson",
-    "http-types==0.0.11",
-    # kafka
-    "faust",
-    # server
-    "tornado==5.1.1",
-    "urllib3==1.25.6",
->>>>>>> 24547dc... Add flake8, black, etc.
 ]
 
 BUNDLES = {}
@@ -65,8 +45,7 @@ BUNDLE_REQUIREMENTS = [dep for _, bundle_dep in BUNDLES.items()
                        for dep in bundle_dep]
 
 DEV = BUNDLE_REQUIREMENTS + [
-    "autopep8",
-    "black==19.10b0",  # black hack for pipenv https://github.com/psf/black/issues/209
+    "black==19.10b0",
     "flake8",
     "pyhamcrest",
     "pylint",
@@ -81,11 +60,7 @@ DEV = BUNDLE_REQUIREMENTS + [
     "wheel",
 ]
 
-<<<<<<< HEAD
 VERSION = '0.2.16'
-=======
-VERSION = "0.2.13"
->>>>>>> 24547dc... Add flake8, black, etc.
 
 ENTRY_POINTS = ["meeshkan = meeshkan.__main__:cli"]
 
@@ -129,16 +104,15 @@ class SetupCommand(Command):
 
 
 BUILD_COMMAND = "{executable} setup.py sdist bdist_wheel --universal".format(
-    executable=sys.executable
-)
+    executable=sys.executable)
 
 TYPE_CHECK_COMMAND = "pyright --lib"
 
 TEST_COMMAND = "pytest"
 
-LINT_COMMAND = "flake8"
+LINT_COMMAND = "flake8 --exclude .git,.venv,__pycache__,build,dist"
 
-FORMAT_COMMAND = "black ."
+FORMAT_COMMAND = "black --check ."
 FORMAT_CHECK_COMMAND = "black --check ."
 
 
@@ -156,10 +130,6 @@ def run_tests():
 
 def lint():
     run_sys_command(LINT_COMMAND, "Linting failed")
-
-
-def check_format():
-    run_sys_command(FORMAT_CHECK_COMMAND, "Format-check failed")
 
 
 def run_formatting():
@@ -193,13 +163,13 @@ class TestCommand(SetupCommand):
     description = "Run tests, formatting, type-checks, and linting"
 
     def run(self):
-        self.status("Checking formatting...")
-        check_format()
+        self.status("Formatting code with black...")
+        run_formatting()
 
-        self.status("Checking style...")
+        self.status("Running flake8...")
         lint()
 
-        self.status("Checking types...")
+        self.status("Running type-checking...")
         type_check()
 
         self.status("Running pytest...")
@@ -257,4 +227,6 @@ setup(
         "test": TestCommand,
         "typecheck": TypeCheckCommand,
     },
+
+
 )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ BUNDLE_REQUIREMENTS = [dep for _, bundle_dep in BUNDLES.items()
 
 DEV = BUNDLE_REQUIREMENTS + [
     "autopep8",
-    "black",
+    "black=19.10b0",  # black hack for pipenv https://github.com/psf/black/issues/209
     "flake8",
     "pyhamcrest",
     "pylint",

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ TEST_COMMAND = "pytest"
 
 LINT_COMMAND = "flake8 --exclude .git,.venv,__pycache__,build,dist"
 
-FORMAT_COMMAND = "black --check ."
+FORMAT_COMMAND = "black ."
 FORMAT_CHECK_COMMAND = "black --check ."
 
 

--- a/setup.py
+++ b/setup.py
@@ -163,11 +163,13 @@ class TestCommand(SetupCommand):
     description = "Run tests, formatting, type-checks, and linting"
 
     def run(self):
-        self.status("Checking formatting...")
-        check_formatting()
+        # FIXME
+        # self.status("Checking formatting...")
+        # check_formatting()
 
-        self.status("Checking style...")
-        check_style()
+        # FIXME
+        # self.status("Checking style...")
+        # check_style()
 
         self.status("Checking types...")
         type_check()

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ BUNDLE_REQUIREMENTS = [dep for _, bundle_dep in BUNDLES.items()
 
 DEV = BUNDLE_REQUIREMENTS + [
     "autopep8",
-    "black=19.10b0",  # black hack for pipenv https://github.com/psf/black/issues/209
+    "black==19.10b0",  # black hack for pipenv https://github.com/psf/black/issues/209
     "flake8",
     "pyhamcrest",
     "pylint",

--- a/setup.py
+++ b/setup.py
@@ -5,19 +5,20 @@ from shutil import rmtree
 from setuptools import setup, Command, find_packages, errors
 
 # Package meta-data.
-NAME = 'meeshkan'
-DESCRIPTION = 'Reverse engineer services with style'
-URL = 'http://github.com/meeshkan/meeshkan'
-EMAIL = 'dev@meeshkan.com'
-AUTHOR = 'Meeshkan Dev Team'
-REQUIRES_PYTHON = '>=3.6.0'
+NAME = "meeshkan"
+DESCRIPTION = "Reverse engineer services with style"
+URL = "http://github.com/meeshkan/meeshkan"
+EMAIL = "dev@meeshkan.com"
+AUTHOR = "Meeshkan Dev Team"
+REQUIRES_PYTHON = ">=3.6.0"
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
-    long_description = '\n' + f.read()
+with open(os.path.join(here, "README.md"), encoding="utf-8") as f:
+    long_description = "\n" + f.read()
 
 REQUIRED = [
+<<<<<<< HEAD
     'click==7.0',
     'lenses',
     'pyyaml',
@@ -36,38 +37,79 @@ REQUIRED = [
     'tornado==5.1.1',
     'urllib3==1.25.6',
     'daemonocle'
+=======
+    "click",
+    "lenses",
+    "pyyaml",
+    "jsonschema",
+    "dataclasses",  # for 3.6, as it ships with 3.7
+    "faker",
+    "requests",
+    "typing-extensions",
+    "openapi-typed_2>=0.0.2",
+    "typeguard>=2.7.0",
+    "genson",
+    "http-types==0.0.11",
+    # kafka
+    "faust",
+    # server
+    "tornado==5.1.1",
+    "urllib3==1.25.6",
+>>>>>>> 24547dc... Add flake8, black, etc.
 ]
 
-BUNDLES = {
-}
+BUNDLES = {}
 
 # Requirements of all bundles
 BUNDLE_REQUIREMENTS = [dep for _, bundle_dep in BUNDLES.items()
                        for dep in bundle_dep]
 
 DEV = BUNDLE_REQUIREMENTS + [
-    'pytest',
-    'pylint',
-    'pytest-tornado',
-    'requests-mock',
-    'setuptools',
-    'twine',
-    'wheel',
-    'pytest-watch',
-    'pytest-testmon',
-    'pyhamcrest',
-    'pytest-asyncio'
+    "autopep8",
+    "black",
+    "flake8",
+    "pyhamcrest",
+    "pylint",
+    "pytest",
+    "pytest-asyncio",
+    "pytest-testmon",
+    "pytest-tornado",
+    "pytest-watch",
+    "requests-mock",
+    "setuptools",
+    "twine",
+    "wheel",
 ]
 
+<<<<<<< HEAD
 VERSION = '0.2.16'
+=======
+VERSION = "0.2.13"
+>>>>>>> 24547dc... Add flake8, black, etc.
 
-ENTRY_POINTS = ['meeshkan = meeshkan.__main__:cli']
+ENTRY_POINTS = ["meeshkan = meeshkan.__main__:cli"]
 
 EXTRAS = dict(**BUNDLES, dev=DEV)
 
 
+def run_sys_command(cmd, error_msg):
+    """Run command in os.system(), raise if exit_code non-zero.
+
+    Arguments:
+        cmd {[type]} -- Command to run. For example: "pytest"
+        error_msg {[type]} -- Error message to raise at failure
+
+    Raises:
+        errors.DistutilsError: Exited with non-zero exit code.
+    """
+    exit_code = os.system(cmd)
+    if exit_code != 0:
+        raise errors.DistutilsError(error_msg)
+
+
 class SetupCommand(Command):
     """Base class for setup.py commands with no arguments"""
+
     user_options = []
 
     def initialize_options(self):
@@ -79,66 +121,99 @@ class SetupCommand(Command):
     @staticmethod
     def status(s):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(s))
+        print("\033[1m{0}\033[0m".format(s))
 
     def rmdir_if_exists(self, directory):
         self.status("Deleting {}".format(directory))
         rmtree(directory, ignore_errors=True)
 
 
+BUILD_COMMAND = "{executable} setup.py sdist bdist_wheel --universal".format(
+    executable=sys.executable)
+
+TYPE_CHECK_COMMAND = "pyright --lib"
+
+TEST_COMMAND = "pytest"
+
+LINT_COMMAND = "flake8 --exclude .git,.venv,__pycache__,build,dist"
+
+FORMAT_COMMAND = "black --check ."
+FORMAT_CHECK_COMMAND = "black --check ."
+
+
 def build():
-    return os.system(
-        "{executable} setup.py sdist bdist_wheel --universal".format(executable=sys.executable))
+    run_sys_command(BUILD_COMMAND, "Build failed")
 
 
 def type_check():
-    os.system("pyright --lib")
+    run_sys_command(TYPE_CHECK_COMMAND, "Type-checking failed")
+
+
+def run_tests():
+    run_sys_command(TEST_COMMAND, "Tests failed")
+
+
+def lint():
+    run_sys_command(LINT_COMMAND, "Linting failed")
+
+
+def run_formatting():
+    run_sys_command(FORMAT_COMMAND, "Formatting failed")
 
 
 class BuildDistCommand(SetupCommand):
     """Support setup.py upload."""
+
     description = "Build the package."
 
     def run(self):
         self.status("Removing previous builds...")
-        self.rmdir_if_exists(os.path.join(here, 'dist'))
-
+        self.rmdir_if_exists(os.path.join(here, "dist"))
         self.status("Building Source and Wheel (universal) distribution...")
         build()
-        sys.exit()
 
 
 class TypeCheckCommand(SetupCommand):
     """Run type-checking."""
+
     description = "Run type-checking."
 
     def run(self):
         type_check()
-        sys.exit()
 
 
 class TestCommand(SetupCommand):
     """Support setup.py test."""
-    description = "Run local test if they exist"
+
+    description = "Run tests, formatting, type-checks, and linting"
 
     def run(self):
-        os.system("pytest")
-        sys.exit()
+        self.status("Formatting code with black...")
+        run_formatting()
+
+        self.status("Running flake8...")
+        lint()
+
+        self.status("Running type-checking...")
+        type_check()
+
+        self.status("Running pytest...")
+        run_tests()
 
 
 class UploadCommand(SetupCommand):
     """Support setup.py upload."""
+
     description = "Build and publish the package."
 
     def run(self):
 
         self.status("Removing previous builds...")
-        self.rmdir_if_exists(os.path.join(here, 'dist'))
+        self.rmdir_if_exists(os.path.join(here, "dist"))
 
         self.status("Building Source and Wheel (universal) distribution...")
-        exit_code = build()
-        if exit_code != 0:
-            raise errors.DistutilsError("Build failed.")
+        build()
+
         self.status("Uploading the package to PyPI via Twine...")
         os.system("twine upload dist/*")
 
@@ -149,29 +224,34 @@ class UploadCommand(SetupCommand):
         sys.exit()
 
 
-setup(name=NAME,
-      version=VERSION,
-      description=DESCRIPTION,
-      long_description=long_description,
-      long_description_content_type='text/markdown',
-      url=URL,
-      author=AUTHOR,
-      author_email=EMAIL,
-      python_requires=REQUIRES_PYTHON,
-      license='MIT',
-      packages=find_packages(exclude=('tests',)),
-      include_package_data=True,
-      install_requires=REQUIRED,
-      extras_require=EXTRAS,
-      classifiers=[
-          'Programming Language :: Python :: 3',
-          'License :: OSI Approved :: MIT License',
-          'Operating System :: OS Independent',
-      ],
-      zip_safe=False,
-      entry_points={'console_scripts': ENTRY_POINTS},
-      cmdclass={'dist': BuildDistCommand,
-                'upload': UploadCommand,
-                'test': TestCommand,
-                'typecheck': TypeCheckCommand}
-      )
+setup(
+    name=NAME,
+    version=VERSION,
+    description=DESCRIPTION,
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url=URL,
+    author=AUTHOR,
+    author_email=EMAIL,
+    python_requires=REQUIRES_PYTHON,
+    license="MIT",
+    packages=find_packages(exclude=("tests",)),
+    include_package_data=True,
+    install_requires=REQUIRED,
+    extras_require=EXTRAS,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: MIT License",
+        "Operating System :: OS Independent",
+    ],
+    zip_safe=False,
+    entry_points={"console_scripts": ENTRY_POINTS},
+    cmdclass={
+        "dist": BuildDistCommand,
+        "upload": UploadCommand,
+        "test": TestCommand,
+        "typecheck": TypeCheckCommand,
+    },
+
+
+)

--- a/setup.py
+++ b/setup.py
@@ -129,15 +129,16 @@ class SetupCommand(Command):
 
 
 BUILD_COMMAND = "{executable} setup.py sdist bdist_wheel --universal".format(
-    executable=sys.executable)
+    executable=sys.executable
+)
 
 TYPE_CHECK_COMMAND = "pyright --lib"
 
 TEST_COMMAND = "pytest"
 
-LINT_COMMAND = "flake8 --exclude .git,.venv,__pycache__,build,dist"
+LINT_COMMAND = "flake8"
 
-FORMAT_COMMAND = "black --check ."
+FORMAT_COMMAND = "black ."
 FORMAT_CHECK_COMMAND = "black --check ."
 
 
@@ -155,6 +156,10 @@ def run_tests():
 
 def lint():
     run_sys_command(LINT_COMMAND, "Linting failed")
+
+
+def check_format():
+    run_sys_command(FORMAT_CHECK_COMMAND, "Format-check failed")
 
 
 def run_formatting():
@@ -188,13 +193,13 @@ class TestCommand(SetupCommand):
     description = "Run tests, formatting, type-checks, and linting"
 
     def run(self):
-        self.status("Formatting code with black...")
-        run_formatting()
+        self.status("Checking formatting...")
+        check_format()
 
-        self.status("Running flake8...")
+        self.status("Checking style...")
         lint()
 
-        self.status("Running type-checking...")
+        self.status("Checking types...")
         type_check()
 
         self.status("Running pytest...")
@@ -252,6 +257,4 @@ setup(
         "test": TestCommand,
         "typecheck": TypeCheckCommand,
     },
-
-
 )


### PR DESCRIPTION
Now that there are multiple contributors to `meeshkan`, I think we could add formatting and style checks. This PR adds `black` and `flake8` following the example of https://github.com/meeshkan/py-http-types/pull/21 . Style checks are not yet fixed as there are so many of them and they probably require manual work. Therefore the linting step is also skipped in `python setup.py test`. 

- ~**You should only review `setup.py` and `README.md`, everything else is auto-formatted with black**~
- Suggestion for contributors: Switch on auto-formatting with black in your code editor
- [ ]  Add precommit hooks like Fredrik suggested?
- [ ]  Fix style errors and formatting errors