### PR TITLE
Improve documentation and argument handling

### DIFF
--- a/guides/MOCK.md
+++ b/guides/MOCK.md
@@ -1,6 +1,6 @@
 # Mocking with Meeshkan
 
-Meeshkan can be used to create a mock server from an OpenAPI spec using.
+Meeshkan can be used to create a mock server from OpenAPI specifications and optional custom callback scripts.
 
 ## The meeshkan mock command
 
@@ -14,7 +14,7 @@ $ meeshkan mock -i spec_dir/
 And then, in another terminal window, type:
 
 ```bash
-$ curl http://localhost:8000/foo -H '{"Host": "my.api.com", "X-Meeshkan-Schema": "https"}'
+$ curl http://localhost:8000/foo -H "Host: my.api.com" -H "X-Meeshkan-Scheme: https"
 ```
 
 Assuming that the directory `spec_dir/` contains an OpenAPI spec with the server `https://my.api.com`, it will return a mock of the resource `GET /foo`.
@@ -23,13 +23,11 @@ More options for the `meeshkan mock` command an be seen by running `meeshkan moc
 
 ## Callbacks
 
-A directory containing callbacks can be provided in callback_path argument. The default is:
-```bash
-meeshkan mock --callback_path ./callbacks
+To customize responses a directory containing callbacks can be provided in the `callback-path` argument (default: `./callbacks`).
 
-```
-A directory can contain multiple Python scripts. A callback is a function with decorated as 
-tools.meeshkan_server.server.callbacks.callback. Each callback is mapped to an endpoint by providing an HTTP method, a host, and a path.
+This directory can contain multiple Python scripts containing callbacks. A callback is a function decorated as 
+`tools.meeshkan_server.server.callbacks.callback`, each being mapped to an endpoint by a HTTP method, host and path.
+
 ```python
 from meeshkan.server.server.callbacks import callback
 

--- a/guides/MOCK.md
+++ b/guides/MOCK.md
@@ -14,7 +14,7 @@ $ meeshkan mock -i spec_dir/
 And then, in another terminal window, type:
 
 ```bash
-$ curl http://localhost:8000/foo -H "Host: my.api.com" -H "X-Meeshkan-Scheme: https"
+$ curl http://localhost:8000/https://my.api.com/foo
 ```
 
 Assuming that the directory `spec_dir/` contains an OpenAPI spec with the server `https://my.api.com`, it will return a mock of the resource `GET /foo`.

--- a/guides/MOCK.md
+++ b/guides/MOCK.md
@@ -26,7 +26,7 @@ More options for the `meeshkan mock` command an be seen by running `meeshkan moc
 To customize responses a directory containing callbacks can be provided in the `callback-path` argument (default: `./callbacks`).
 
 This directory can contain multiple Python scripts containing callbacks. A callback is a function decorated as 
-`tools.meeshkan_server.server.callbacks.callback`, each being mapped to an endpoint by a HTTP method, host and path.
+`meeshkan_server.server.callbacks.callback`, each being mapped to an endpoint by a HTTP method, host and path.
 
 ```python
 from meeshkan.server.server.callbacks import callback

--- a/guides/RECORD.md
+++ b/guides/RECORD.md
@@ -37,7 +37,7 @@ $ meeshkan record -r
 Then, in another terminal window, run:
 
 ```bash
-$ curl http://localhost:8000/api/v2/pokemon/ditto -H '{"Host":"pokeapi.co", "X-Meeshkan-Schema": "https" }'
+$ curl http://localhost:8000/api/v2/pokemon/ditto -H "Host: pokeapi.co" -H "X-Meeshkan-Scheme: https"
 ```
 
 This instructs meeshkan to call the [Pokemon API](pokeapi.co) and use the HTTPS protocol.

--- a/meeshkan/server/commands.py
+++ b/meeshkan/server/commands.py
@@ -37,10 +37,10 @@ def start_admin(port):
 
 @click.command()
 @click.option('-p', '--port', default="8000", help='Server port.')
-@click.option('-a', '--admin_port', default="8888", help='Admin server port.')
+@click.option('-a', '--admin-port', default="8888", help='Admin server port.')
 @click.option('-l', '--log_dir', default="./logs", help='API calls logs direcotry')
-@click.option('-r', '--header_routing', is_flag=True, help='Whether to use a header based routing to a target host.')
-@click.option('-s', '--specs_dir', default="./specs", help='Directory to store OpenAPI specs.')
+@click.option('-r', '--header-routing', is_flag=True, help='Use header based routing to target hosts.')
+@click.option('-s', '--specs-dir', default="./specs", help='Directory to store OpenAPI specs.')
 @click.option("-m", "--mode", type=click.Choice(['GEN', 'REPLAY', 'MIXED'], case_sensitive=False),
               default=None, help="Spec building mode.")
 def record(port, admin_port, log_dir, header_routing, specs_dir, mode):
@@ -74,11 +74,11 @@ def make_mocking_app(callback_path, specs_dir, router):
 
 
 @click.command()
-@click.option('-c', '--callback_path', default="./callbacks", help='Directory with configured callbacks.')
+@click.option('-c', '--callback-path', default="./callbacks", help='Directory with configured callbacks.')
 @click.option('-p', '--port', default="8000", help='Server port.')
-@click.option('-a', '--admin_port', default="8888", help='Admin server port.')
-@click.option('-s', '--specs_dir', default="./specs", help='Directory with OpenAPI schemas.')
-@click.option('-r', '--header_routing', is_flag=True, help='Whether to use a path based routing to a target host.')
+@click.option('-a', '--admin-port', default="8888", help='Admin server port.')
+@click.option('-s', '--specs-dir', default="./specs", help='Directory with OpenAPI schemas.')
+@click.option('-r', '--header-routing', is_flag=True, help='Use header based routing to target hosts.')
 def mock(callback_path, admin_port, port, specs_dir, header_routing):
     """
     Run a mock server.


### PR DESCRIPTION
- Minor wording changes.
- The `-H '{"Host": "my.api.com", "X-Meeshkan-Scheme": "https"}'` construction does not work for me with curl, replace with `-H "Host: "my.api.com" -H "X-Meeshkan-Scheme: https"` which does.
- Fix typo `X-Meeshkan-Schema` => `X-Meeshkan-Scheme`.
- Use dash instead of underscores in parameters (`--admin_port` => `--admin-port` and similar).
- Fix help text for the `-r, --header_routing` parameter to the mock command to say header routing, not path routing.
- Update `tools.meeshkan_server.server.callbacks.callback` => `meeshkan_server.server.callbacks.callback`.

Note that SERVER.md has not been updated, as it has been deleted in https://github.com/meeshkan/meeshkan/pull/82.