### PR TITLE
Fix body decoding in MockServerView

### DIFF
--- a/meeshkan/server/server/views.py
+++ b/meeshkan/server/server/views.py
@@ -62,8 +62,7 @@ class MockServerView(RequestHandler):
                             'pathname': route_info.path,
                             'protocol': route_info.scheme,
                             'query': query,
-                            'body': str(self.request.body),
-                            'bodyAsJson': self._extract_json_safely(self.request.body),
+                            'body': self.request.body.decode('utf-8'),
                             'headers': headers})
 
         logger.debug(request)
@@ -72,12 +71,3 @@ class MockServerView(RequestHandler):
             self.set_header(header, value)
 
         self.write(response.body)
-
-    def _extract_json_safely(self, text):
-        if text:
-            try:
-                return json.loads(text)
-            except Exception as e:
-                pass
-
-        return {}

--- a/tests/server/server/callbacks/callbacks.py
+++ b/tests/server/server/callbacks/callbacks.py
@@ -10,6 +10,7 @@ def counter_callback(request_body, response_body, storage):
     response_body['count'] = storage['called']
     return response_body
 
+
 @callback('api.com', 'get', '/text_counter', format='text')
 def counter_callback(query, response_body, storage):
     if 'set' in query:
@@ -17,3 +18,8 @@ def counter_callback(query, response_body, storage):
     else:
         storage['called'] = storage.get('called', 0) + 1
     return "{} {} times".format(response_body, storage['called'])
+
+
+@callback('petstore.swagger.io', 'post', '/v1/pets', format='text')
+def echo_callback(request_body):
+    return request_body

--- a/tests/server/server/test_body_echoing.py
+++ b/tests/server/server/test_body_echoing.py
@@ -1,0 +1,21 @@
+import pytest
+
+from meeshkan.server import make_mocking_app
+from meeshkan.server.utils.routing import PathRouting
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+
+
+@pytest.fixture
+def app():
+    return make_mocking_app("tests/server/server/callbacks", "tests/server/mock/petstore_schema", PathRouting())
+
+
+@pytest.mark.gen_test
+def test_body_echoing(http_client: AsyncHTTPClient, base_url: str):
+    req = HTTPRequest(
+        url=base_url + "/http://petstore.swagger.io/v1/pets",
+        method="POST",
+        body="hello, world",
+    )
+    ret = yield http_client.fetch(req)
+    assert ret.body.decode("utf-8") == "hello, world"


### PR DESCRIPTION
Calling`str(self.request.body)` when self.request.body is a bytes instance does not work, instead we should decode the bytes.

Since we now get the correct decoded body, we can drop `_extract_json_safel` as py-http-types takes care of the same thing.