### PR TITLE
Do not use a default callbacks directory

### DIFF
--- a/docs/MOCK.md
+++ b/docs/MOCK.md
@@ -36,7 +36,7 @@ $ meeshkan mock stop
 
 ## Callbacks
 
-To customize responses a directory containing callbacks can be provided in the `callback-path` argument (default: `./callbacks`).
+To customize responses a directory containing callbacks can be provided in the `callback-dir` argument.
 
 This directory can contain multiple Python scripts containing callbacks. A callback is a function decorated as 
 `meeshkan_server.server.callbacks.callback`, each being mapped to an endpoint by a HTTP method, host and path.

--- a/meeshkan/server/commands.py
+++ b/meeshkan/server/commands.py
@@ -12,7 +12,6 @@ from ..config import DEFAULT_SPECS_DIR
 from ..schemabuilder import UpdateMode
 
 LOG_CONFIG = os.path.join(os.path.dirname(__file__), 'logging.yaml')
-
 MOCK_PID = Path.home().joinpath('.meeshkan/mock.pid')
 RECORD_PID = Path.home().joinpath('.meeshkan/record.pid')
 
@@ -45,15 +44,15 @@ _mock_options = _common_server_options + [
 @click.group(invoke_without_command=True)
 @add_options(_mock_options)
 @click.pass_context
-def mock(ctx, callback_path, admin_port, port, specs_dir, header_routing, daemon):
+def mock(ctx, callback_dir, admin_port, port, specs_dir, header_routing, daemon):
     if ctx.invoked_subcommand is None:
         ctx.forward(start_mock)
 
 
 @mock.command(name='start')  # type: ignore
 @add_options(_mock_options)
-def start_mock(callback_path, admin_port, port, specs_dir, header_routing, daemon):
-    server = MockServer(callback_path=callback_path, admin_port=admin_port, port=port, specs_dir=specs_dir,
+def start_mock(callback_dir, admin_port, port, specs_dir, header_routing, daemon):
+    server = MockServer(callback_dir=callback_dir, admin_port=admin_port, port=port, specs_dir=specs_dir,
                         routing=HeaderRouting() if header_routing else PathRouting())
 
     if daemon and (not IS_WINDOWS):

--- a/meeshkan/server/commands.py
+++ b/meeshkan/server/commands.py
@@ -38,7 +38,7 @@ _record_options = _common_server_options + [
                  default=None, help="Spec building mode.")]
 
 _mock_options = _common_server_options + [
-    click.option('-c', '--callback-path', default="./callbacks", help='Directory with configured callbacks.')]
+    click.option('-c', '--callback-dir', default="./callbacks", help='Directory with configured callbacks.')]
 
 
 @click.group(invoke_without_command=True)

--- a/meeshkan/server/server/callbacks.py
+++ b/meeshkan/server/server/callbacks.py
@@ -3,11 +3,10 @@ import importlib.util
 import inspect
 import json
 import logging
-from dataclasses import asdict, replace
+from dataclasses import asdict
 import os
-from io import StringIO
-from http_types import HttpExchange
-from http_types.utils import ResponseBuilder, HttpExchangeWriter
+import sys
+from http_types.utils import ResponseBuilder
 
 from .storage import storage_manager
 
@@ -38,8 +37,9 @@ class CallbackManager:
         self._callbacks = dict()
 
     def load(self, path):
-        if not path or not os.path.exists(path):
-            logger.debug("Callback configuration path doesn't exist %s", path)
+        if not os.path.exists(path):
+            logger.fatal("Callback configuration path doesn't exist: %s", path)
+            sys.exit(1)
 
         for f in glob.glob(os.path.join(path, '*.py')):
             module_name = 'callbacks.{}'.format(os.path.splitext(os.path.basename(f))[0])

--- a/meeshkan/server/server/server.py
+++ b/meeshkan/server/server/server.py
@@ -18,11 +18,12 @@ class MeeshkanApplication(Application):
     router: Routing
 
 
-def make_mocking_app(callback_path, specs_dir, routing):
+def make_mocking_app(callback_dir, specs_dir, routing):
     app = MeeshkanApplication([
         (r'/.*', MockServerView)
     ])
-    callback_manager.load(callback_path)
+    if callback_dir:
+        callback_manager.load(callback_dir)
 
     app.response_matcher = ResponseMatcher(specs_dir)
     app.router = routing
@@ -30,8 +31,8 @@ def make_mocking_app(callback_path, specs_dir, routing):
 
 
 class MockServer:
-    def __init__(self, port, specs_dir, callback_path=None, admin_port=None, routing=PathRouting()):
-        self._callback_path = callback_path
+    def __init__(self, port, specs_dir, callback_dir=None, admin_port=None, routing=PathRouting()):
+        self._callback_dir = callback_dir
         self._admin_port = admin_port
         self._port = port
         self._specs_dir = specs_dir
@@ -40,7 +41,7 @@ class MockServer:
     def run(self):
         if self._admin_port:
             start_admin(self._admin_port)
-        app = make_mocking_app(self._callback_path, self._specs_dir, self._routing)
+        app = make_mocking_app(self._callback_dir, self._specs_dir, self._routing)
         http_server = HTTPServer(app)
         http_server.listen(self._port)
         logger.info('Mock server is listening on http://localhost:%s', self._port)


### PR DESCRIPTION
Callback usage should be explicit and not default to some directory.

Avoid this default directory gets rid of this startup message for everyone not using callbacks:
> DEBUG - Callback configuration path doesn't exist ./callbacks

Instead we can now exit with an error if the specified callbacks directory does not exist, instead of just noting it at DEBUG level.

Also rename --callback-path to --callback-dir to harmonize with --specs-dir and --log-dir naming.