### PR TITLE
Replace sys.exit() with throwing of an exception

### DIFF
--- a/meeshkan/serve/mock/callbacks.py
+++ b/meeshkan/serve/mock/callbacks.py
@@ -38,8 +38,7 @@ class CallbackManager:
 
     def load(self, path):
         if not os.path.exists(path):
-            logger.fatal("Callback configuration path doesn't exist: %s", path)
-            sys.exit(1)
+            raise FileNotFoundError(f"Callback configuration path doesn't exist: {path}")
 
         for f in glob.glob(os.path.join(path, '*.py')):
             module_name = 'callbacks.{}'.format(os.path.splitext(os.path.basename(f))[0])


### PR DESCRIPTION
Also catch exceptions at the top level of servers, exiting without showing a stack trace unless a --verbose flag has been specified.

Fixes #105.

What do you think, is this the right approach? I think in the daemon case it's more ok to show stack traces, as it's more like server usage.