### PR TITLE
Replace sys.exit() with exception

### DIFF
--- a/meeshkan/serve/commands.py
+++ b/meeshkan/serve/commands.py
@@ -38,7 +38,7 @@ _record_options = _common_server_options + [
                  default=None, help="Spec building mode.")]
 
 _mock_options = _common_server_options + [
-    click.option('-c', '--callback-dir', default="./callbacks", help='Directory with configured callbacks.')]
+    click.option('-c', '--callback-dir', default=None, type=click.Path(exists=True, file_okay=False, resolve_path=True), help='Directory with configured callbacks.')]
 
 
 @click.group(invoke_without_command=True)

--- a/meeshkan/serve/mock/callbacks.py
+++ b/meeshkan/serve/mock/callbacks.py
@@ -37,9 +37,8 @@ class CallbackManager:
         self._callbacks = dict()
 
     def load(self, path):
-        if not os.path.exists(path):
-            logger.fatal("Callback configuration path doesn't exist: %s", path)
-            sys.exit(1)
+        if not os.path.isdir(path):
+            raise FileNotFoundError(f"Callback configuration directory doesn't exist: {path}")
 
         for f in glob.glob(os.path.join(path, '*.py')):
             module_name = 'callbacks.{}'.format(os.path.splitext(os.path.basename(f))[0])


### PR DESCRIPTION
Let click validate that the callback directory exists. Fixes #105.

Replaced #108 with this, thanks @aby2s for the tip about letting click validate the parameters.