### PR TITLE
Shorten log format

### DIFF
--- a/meeshkan/logging.yaml
+++ b/meeshkan/logging.yaml
@@ -2,7 +2,7 @@ version: 1
 disable_existing_loggers: False
 formatters:
     simple:
-        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        format: "%(message)s"
 
 handlers:
     console_handler:

--- a/meeshkan/logging.yaml
+++ b/meeshkan/logging.yaml
@@ -3,6 +3,8 @@ disable_existing_loggers: False
 formatters:
     simple:
         format: "%(message)s"
+    complete:
+        format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 handlers:
     console_handler:
@@ -14,7 +16,7 @@ handlers:
     debug_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: DEBUG
-        formatter: simple
+        formatter: complete
         filename: debug.log # Prepended with correct directory in application code
         maxBytes: 20971520 # 20MB
         backupCount: 20
@@ -23,7 +25,7 @@ handlers:
     info_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: INFO
-        formatter: simple
+        formatter: complete
         filename: info.log # Prepended with correct directory in application code
         maxBytes: 10485760 # 10MB
         backupCount: 20
@@ -32,7 +34,7 @@ handlers:
     error_file_handler:
         class: logging.handlers.RotatingFileHandler
         level: ERROR
-        formatter: simple
+        formatter: complete
         filename: errors.log # Prepended with correct directory in application code
         maxBytes: 10485760 # 10MB
         backupCount: 20

--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -26,4 +26,4 @@ def start_admin(port):
     app = make_admin_app()
     http_server = HTTPServer(app)
     http_server.listen(port)
-    logger.info("Starting admin endpont on http://localhost:%s/admin", port)
+    logger.info("Starting admin endpoint on http://localhost:%s/admin", port)

--- a/meeshkan/serve/mock/server.py
+++ b/meeshkan/serve/mock/server.py
@@ -44,5 +44,5 @@ class MockServer:
         app = make_mocking_app(self._callback_dir, self._specs_dir, self._routing)
         http_server = HTTPServer(app)
         http_server.listen(self._port)
-        logger.info("Mock mock is listening on http://localhost:%s", self._port)
+        logger.info("Mock is listening on http://localhost:%s", self._port)
         IOLoop.current().start()


### PR DESCRIPTION
- What do you think about this change?
- Should we use a different log format for when running as a daemon?

Before
```sh
$ meeshkan record
2020-03-11 15:16:25,205 - meeshkan.serve.admin.runner - INFO - Starting admin endpont on http://localhost:8888/admin
2020-03-11 15:16:25,205 - meeshkan.serve.record.proxy - INFO - Starting Meeshkan record on http://localhost:8000
2020-03-11 15:16:25,205 - meeshkan.serve.record.proxy - INFO - Spec generation mode is disabled
```

After:
```sh
$ meeshkan record
Starting admin endpoint on http://localhost:8888/admin
Starting Meeshkan record on http://localhost:8000
Spec generation mode is disabled
```

Future improvements could be adding color and/or emojis to make the output come alive a bit.
