### PR TITLE
Allow specifying an OpenAPI spec file directly

### DIFF
--- a/docs/MOCK.md
+++ b/docs/MOCK.md
@@ -8,7 +8,7 @@ To create a mock server from an OpenAPI spec, use the `meeshkan mock` command.
 
 ```bash
 $ pip install meeshkan
-$ meeshkan mock --specs-dir spec_dir/
+$ meeshkan mock --specs spec_file.yaml
 ```
 
 And then, in another terminal window, type:
@@ -17,7 +17,7 @@ And then, in another terminal window, type:
 $ curl http://localhost:8000/https://my.api.com/foo
 ```
 
-Assuming that the directory `spec_dir/` contains an OpenAPI spec with the server `https://my.api.com`, it will return a mock of the resource `GET /foo`.
+Assuming that the directory `spec_file.yaml` is an OpenAPI spec with the server `https://my.api.com`, it will return a mock of the resource `GET /foo`.
 
 More options for the `meeshkan mock` command an be seen by running `meeshkan mock --help`.
 

--- a/meeshkan/serve/commands.py
+++ b/meeshkan/serve/commands.py
@@ -29,9 +29,10 @@ _common_server_options = [
     click.option("-a", "--admin-port", default="8888", help="Admin server port."),
     click.option(
         "-s",
-        "--specs-dir",
+        "--specs",
         default=DEFAULT_SPECS_DIR,
-        help="Directory with OpenAPI specifications.",
+        type=click.Path(exists=True, file_okay=True, dir_okay=True, readable=True),
+        help="OpenAPI specification(s) to mock.",
     ),
     click.option("-d", "--daemon", is_flag=True, help="Run meeshkan as a daemon."),
     click.option(
@@ -67,7 +68,7 @@ _mock_options = _common_server_options + [
 @click.group(invoke_without_command=True)
 @add_options(_mock_options)
 @click.pass_context
-def mock(ctx, callback_dir, admin_port, port, specs_dir, header_routing, daemon):
+def mock(ctx, callback_dir, admin_port, port, specs, header_routing, daemon):
     """
     Run a mock server using OpenAPI specifications.
     """
@@ -77,12 +78,12 @@ def mock(ctx, callback_dir, admin_port, port, specs_dir, header_routing, daemon)
 
 @mock.command(name="start")  # type: ignore
 @add_options(_mock_options)
-def start_mock(callback_dir, admin_port, port, specs_dir, header_routing, daemon):
+def start_mock(callback_dir, admin_port, port, specs, header_routing, daemon):
     server = MockServer(
         callback_dir=callback_dir,
         admin_port=admin_port,
         port=port,
-        specs_dir=specs_dir,
+        specs=specs,
         routing=HeaderRouting() if header_routing else PathRouting(),
     )
 

--- a/meeshkan/serve/mock/response_matcher.py
+++ b/meeshkan/serve/mock/response_matcher.py
@@ -31,19 +31,23 @@ logger = logging.getLogger(__name__)
 class ResponseMatcher:
     _schemas: Mapping[str, OpenAPIObject]
 
-    def __init__(self, specs_dir):
-        schemas: Sequence[str] = []
-        if not os.path.exists(specs_dir):
-            logging.info("OpenAPI schema directory not found %s", specs_dir)
-        else:
+    def __init__(self, specs_dir_or_file):
+        schemas: Sequence[str]
+        if os.path.isfile(specs_dir_or_file):
+            schemas = [specs_dir_or_file]
+        elif os.path.isdir(specs_dir_or_file):
             schemas = [
-                s
-                for s in os.listdir(specs_dir)
+                os.path.join(specs_dir_or_file, s)
+                for s in os.listdir(specs_dir_or_file)
                 if s.endswith("yml") or s.endswith("yaml") or s.endswith("json")
             ]
+        else:
+            raise FileNotFoundError(
+                "OpenAPI schema path not found %s", specs_dir_or_file
+            )
         specs: Sequence[Tuple[str, OpenAPIObject]] = []
         for schema in schemas:
-            with open(os.path.join(specs_dir, schema), encoding="utf8") as schema_file:
+            with open(schema, encoding="utf8") as schema_file:
                 # TODO: validate schema?
                 specs = [
                     *specs,

--- a/meeshkan/serve/mock/server.py
+++ b/meeshkan/serve/mock/server.py
@@ -18,30 +18,30 @@ class MeeshkanApplication(Application):
     router: Routing
 
 
-def make_mocking_app(callback_dir, specs_dir, routing):
+def make_mocking_app(callback_dir, specs, routing):
     app = MeeshkanApplication([(r"/.*", MockServerView)])
     if callback_dir:
         callback_manager.load(callback_dir)
 
-    app.response_matcher = ResponseMatcher(specs_dir)
+    app.response_matcher = ResponseMatcher(specs)
     app.router = routing
     return app
 
 
 class MockServer:
     def __init__(
-        self, port, specs_dir, callback_dir=None, admin_port=None, routing=PathRouting()
+        self, port, specs, callback_dir=None, admin_port=None, routing=PathRouting()
     ):
         self._callback_dir = callback_dir
         self._admin_port = admin_port
         self._port = port
-        self._specs_dir = specs_dir
+        self._specs = specs
         self._routing = routing
 
     def run(self):
         if self._admin_port:
             start_admin(self._admin_port)
-        app = make_mocking_app(self._callback_dir, self._specs_dir, self._routing)
+        app = make_mocking_app(self._callback_dir, self._specs, self._routing)
         http_server = HTTPServer(app)
         http_server.listen(self._port)
         logger.info("Mock mock is listening on http://localhost:%s", self._port)

--- a/tests/serve/mock/test_control_via_rest.py
+++ b/tests/serve/mock/test_control_via_rest.py
@@ -13,7 +13,7 @@ from meeshkan.serve.utils.routing import HeaderRouting
 def app():
     return make_mocking_app(
         "tests/serve/mock/callbacks",
-        "tests/serve/mock/shemas/petstore",
+        "tests/serve/mock/schemas/petstore",
         HeaderRouting(),
     )
 


### PR DESCRIPTION
Using the command as `meeshkan mock --specs spec_file.yaml` is probably more natural and less to remember, especially as most people will probably (at least start with) mocking only one OpenAPI specification file.

We still support the `--specs` option to point at a directory just as before as well.

We also start validating the argument, so in the case of a non-existing specs, we show a descriptive error message instead of starting a mock server without any mocks:

```sh
$ meeshkan mock --specs non-existing
Usage: meeshkan mock [OPTIONS] COMMAND [ARGS]...
Try "meeshkan mock --help" for help.

Error: Invalid value for "-s" / "--specs": Path "non-existing" does not exist.
```

Ideally I think we should have have `meeshkan mock spec_file.yaml` without any options, but the daemon argument handling currently complicates that, so this is a start.