### PR TITLE
Avoid nagging about 'pip install meeshkan'

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Let's look at how to build a Meeshkan spec. First, you have to **collect** recor
 To record API traffic, the Meeshkan CLI provides a `record` mode that captures API traffic using a proxy.
 
 ```bash
-$ pip install meeshkan # if not installed yet
 $ meeshkan record
 ```
 
@@ -110,7 +109,6 @@ For more information about recording, including direct file writing and kafka st
 Using the Meeshkan CLI, you can **build** an OpenAPI schema from a single `.jsonl` file, in addition to any existing OpenAPI specs that describe how a service works.
 
 ```bash
-$ pip install meeshkan # if not done yet
 $ meeshkan build -i path/to/recordings.jsonl [-o path/to/output_directory]
 ```
 
@@ -141,7 +139,6 @@ For more information about building, including mixing together the two modes and
 You can use an OpenAPI spec, such as the one created with `meeshkan build`, to create a **mock** server using Meeshkan.
 
 ```bash
-$ pip install meeshkan # if not installed yet
 $ meeshkan mock
 ```
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -10,8 +10,7 @@ In case one only has an OpenAPI spec and no server recodings, it is not necessar
 
 To build an OpenAPI spec from recorded HTTP API traffic and other OpenAPI specs, use the `meeshkan build` command.
 
-```
-$ pip install meeshkan
+```sh
 $ meeshkan build -i my_recoding.jsonl -a my_openapi_spec.yml -o result/
 ```
 

--- a/docs/MOCK.md
+++ b/docs/MOCK.md
@@ -7,7 +7,6 @@ Meeshkan can be used to create a mock server from OpenAPI specifications and opt
 To create a mock server from an OpenAPI spec, use the `meeshkan mock` command.
 
 ```bash
-$ pip install meeshkan
 $ meeshkan mock --specs-dir spec_dir/
 ```
 

--- a/docs/RECORD.md
+++ b/docs/RECORD.md
@@ -6,8 +6,7 @@ Meeshkan can be used to record HTTP API traffic in a format that `meeshkan build
 
 To start a Meeshkan server that will record HTTP API traffic, use the `meeshkan record` command.
 
-```
-$ pip install meeshkan # if not installed yet
+```sh
 $ meeshkan record
 ```
 This starts Meeshkan as a reverse proxy on the default port of `8000`.


### PR DESCRIPTION
We show installations instructions once, we don't need to nag about `pip install meeshkan` later on, especially as people now may start installing the tool using other ways such as homebrew or apt.