### PR TITLE
Avoid globals when initializing views.

### DIFF
--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -1,4 +1,6 @@
 import logging
+from meeshkan.serve.mock.rest import rest_middleware_manager
+from meeshkan.serve.mock.storage import storage_manager
 
 from tornado.httpserver import HTTPServer
 from tornado.web import Application
@@ -12,12 +14,24 @@ from meeshkan.serve.admin.views import (
 logger = logging.getLogger(__name__)
 
 
-def make_admin_app():
+def make_admin_app(
+    storage_manager=storage_manager, rest_middleware_manager=rest_middleware_manager
+):
+    storage_view_deps = dict(storage_manager=storage_manager)
+    rest_middleware_deps = dict(rest_middleware_manager=rest_middleware_manager)
     return Application(
         [
-            (r"/admin/storage", StorageView),
-            (r"/admin/middleware/rest/pregen", RestMiddlewaresView),
-            (r"/admin/middleware/rest/pregen/(.+)", RestMiddlewareView),
+            (r"/admin/storage", StorageView, storage_view_deps),
+            (
+                r"/admin/middleware/rest/pregen",
+                RestMiddlewaresView,
+                rest_middleware_deps,
+            ),
+            (
+                r"/admin/middleware/rest/pregen/(.+)",
+                RestMiddlewareView,
+                rest_middleware_deps,
+            ),
         ]
     )
 

--- a/meeshkan/serve/admin/views.py
+++ b/meeshkan/serve/admin/views.py
@@ -2,8 +2,8 @@ import logging
 
 from tornado.web import RequestHandler
 
-from ..mock.storage import storage_manager
-from ..mock.rest import rest_middleware_manager
+from ..mock.storage import StorageManager
+from ..mock.rest import RestMiddlewareManager
 import json
 
 logger = logging.getLogger(__name__)
@@ -12,34 +12,43 @@ logger = logging.getLogger(__name__)
 class StorageView(RequestHandler):
     SUPPORTED_METHODS = ["DELETE"]
 
+    def initialize(self, storage_manager: StorageManager):
+        self.storage_manager = storage_manager
+
     def set_default_headers(self):
         self.set_header("Content-Type", 'application/json; charset="utf-8"')
 
     def delete(self):
-        storage_manager.clear()
+        self.storage_manager.clear()
 
 
 class RestMiddlewaresView(RequestHandler):
     SUPPORTED_METHODS = ["DELETE", "GET"]
 
+    def initialize(self, rest_middleware_manager: RestMiddlewareManager):
+        self.rest_middleware_manager = rest_middleware_manager
+
     def set_default_headers(self):
         self.set_header("Content-Type", 'application/json; charset="utf-8"')
 
     def delete(self):
-        rest_middleware_manager.clear()
+        self.rest_middleware_manager.clear()
 
     def get(self):
-        self.write(json.dumps(rest_middleware_manager.get()))
+        self.write(json.dumps(self.rest_middleware_manager.get()))
 
 
 class RestMiddlewareView(RequestHandler):
     SUPPORTED_METHODS = ["DELETE", "POST"]
 
+    def initialize(self, rest_middleware_manager: RestMiddlewareManager):
+        self.rest_middleware_manager = rest_middleware_manager
+
     def set_default_headers(self):
         self.set_header("Content-Type", 'application/json; charset="utf-8"')
 
     def delete(self, url):
-        rest_middleware_manager.clear(url)
+        self.rest_middleware_manager.clear(url)
 
     def post(self, url):
-        rest_middleware_manager.add(url)
+        self.rest_middleware_manager.add(url)

--- a/meeshkan/serve/mock/server.py
+++ b/meeshkan/serve/mock/server.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
@@ -24,10 +25,10 @@ def make_mocking_app_(
     return Application([(r"/.*", MockServerView, dependencies)])
 
 
-def make_mocking_app(callback_dir: str, specs_dir: str, routing: Routing):
+def make_mocking_app(callback_dir: Optional[str], specs_dir: str, routing: Routing):
 
     # callback_manager = CallbackManager()
-    if callback_dir:
+    if callback_dir is not None:
         callback_manager.load(callback_dir)
 
     response_matcher = ResponseMatcher(specs_dir)

--- a/tests/serve/mock/test_views.py
+++ b/tests/serve/mock/test_views.py
@@ -6,30 +6,39 @@ from http_types import HttpMethod, Protocol
 from http_types.utils import ResponseBuilder
 from tornado.httpclient import HTTPRequest
 
-from meeshkan.serve.mock.server import make_mocking_app
+from meeshkan.serve.mock.server import make_mocking_app_
 from meeshkan.serve.utils.routing import HeaderRouting
+from meeshkan.serve.mock.response_matcher import ResponseMatcher
+from meeshkan.serve.mock.callbacks import callback_manager
+
+response = ResponseBuilder.from_dict(
+    dict(
+        statusCode=200,
+        body='{"message": "hello"}',
+        bodyAsJson=json.loads('{"message": "hello"}'),
+        headers={},
+    )
+)
+get_response_mock = Mock(return_value=response)
 
 
 @pytest.fixture
 def app():
-    return make_mocking_app(
-        "tests/serve/mock/callbacks",
-        "tests/serve/mock/schemas/petstore",
-        HeaderRouting(),
+    callback_manager.load("tests/serve/mock/callbacks")
+    response_matcher = ResponseMatcher("tests/serve/mock/schemas/petstore")
+
+    response_matcher.get_response = get_response_mock
+
+    app = make_mocking_app_(
+        callback_manager=callback_manager,
+        response_matcher=response_matcher,
+        router=HeaderRouting(),
     )
+    return app
 
 
 @pytest.mark.gen_test
 def test_mocking_server_pets(http_client, base_url, app):
-    response = ResponseBuilder.from_dict(
-        dict(
-            statusCode=200,
-            body='{"message": "hello"}',
-            bodyAsJson=json.loads('{"message": "hello"}'),
-            headers={},
-        )
-    )
-    app.response_matcher.get_response = Mock(return_value=response)
 
     req = HTTPRequest(base_url + "/pets", headers={"Host": "petstore.swagger.io"})
     http_response = yield http_client.fetch(req)
@@ -37,8 +46,8 @@ def test_mocking_server_pets(http_client, base_url, app):
     rb = json.loads(http_response.body)
     assert {"message": "hello"} == rb
 
-    assert len(app.response_matcher.get_response.call_args_list) == 1
-    request = app.response_matcher.get_response.call_args_list[0][0][0]
+    assert len(get_response_mock.call_args_list) == 1
+    request = get_response_mock.call_args_list[0][0][0]
     assert HttpMethod.GET == request.method
     assert Protocol.HTTP == request.protocol
     assert "/pets" == request.pathname


### PR DESCRIPTION
When creating `MockServerView`, its dependencies are injected either via a global variable (`callback_manager` loaded from given directory) or via `MeeshkanApplication`. I think the "official" way to inject dependencies is to use [RequestHandler.initialize](https://www.tornadoweb.org/en/stable/web.html#entry-points), to me it makes the flow easier to understand as it's more explicit.

~I would also like to avoid using a global `callback_manager` as it makes the tests dependent on each other, couldn't one just create a new `CallbackManager` when creating a server?~ Now I understand why it's a global, it's because the decorators need to add callbacks somewhere.

What do you think? 