### PR TITLE
Adds scope for server

### DIFF
--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -4,10 +4,10 @@ from tornado.httpserver import HTTPServer
 from tornado.web import Application
 
 from meeshkan.serve.admin.views import (
-    ScopeView,
-    StorageView,
     RestMiddlewaresView,
     RestMiddlewareView,
+    ScopeView,
+    StorageView,
 )
 from meeshkan.serve.mock.rest import rest_middleware_manager
 from meeshkan.serve.mock.storage import storage_manager

--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -4,6 +4,7 @@ from tornado.httpserver import HTTPServer
 from tornado.web import Application
 
 from meeshkan.serve.admin.views import (
+    ScopeView,
     StorageView,
     RestMiddlewaresView,
     RestMiddlewareView,
@@ -16,6 +17,7 @@ def make_admin_app():
     return Application(
         [
             (r"/admin/storage", StorageView),
+            (r"/admin/scope", ScopeView),
             (r"/admin/middleware/rest/pregen", RestMiddlewaresView),
             (r"/admin/middleware/rest/pregen/(.+)", RestMiddlewareView),
         ]

--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -12,17 +12,22 @@ from meeshkan.serve.admin.views import (
 from meeshkan.serve.mock.rest import rest_middleware_manager
 from meeshkan.serve.mock.storage import storage_manager
 
+from ..mock.scope import Scope
+
 logger = logging.getLogger(__name__)
 
 
 def make_admin_app(
-    storage_manager=storage_manager, rest_middleware_manager=rest_middleware_manager
+    scope,
+    storage_manager=storage_manager,
+    rest_middleware_manager=rest_middleware_manager,
 ):
     storage_view_deps = dict(storage_manager=storage_manager)
     rest_middleware_deps = dict(rest_middleware_manager=rest_middleware_manager)
+    scope_view_deps = dict(scope=scope)
     return Application(
         [
-            (r"/admin/scope", ScopeView),
+            (r"/admin/scope", ScopeView, scope_view_deps),
             (r"/admin/storage", StorageView, storage_view_deps),
             (
                 r"/admin/middleware/rest/pregen",
@@ -38,8 +43,8 @@ def make_admin_app(
     )
 
 
-def start_admin(port):
-    app = make_admin_app()
+def start_admin(port, scope: Scope):
+    app = make_admin_app(scope)
     http_server = HTTPServer(app)
     http_server.listen(port)
     logger.info("⚙ Admin   http://localhost:%s/admin", port)

--- a/meeshkan/serve/admin/views.py
+++ b/meeshkan/serve/admin/views.py
@@ -4,7 +4,7 @@ import logging
 from tornado.web import RequestHandler
 
 from ..mock.rest import RestMiddlewareManager
-from ..mock.scope import scope_manager
+from ..mock.scope import Scope
 from ..mock.storage import StorageManager
 
 logger = logging.getLogger(__name__)
@@ -26,16 +26,19 @@ class StorageView(RequestHandler):
 class ScopeView(RequestHandler):
     SUPPORTED_METHODS = ["DELETE", "POST", "GET"]
 
+    def initialize(self, scope: Scope):
+        self.scope = scope
+
     def delete(self):
-        scope_manager.clear()
+        self.scope.clear()
 
     def post(self):
-        scope_manager.set(self.get_body_argument("name"))
+        self.scope.set(self.get_body_argument("name"))
 
     def get(self):
         self.set_header("Content-Type", 'application/json; charset="utf-8"')
         return self.write(
-            dict() if scope_manager.get() is None else dict(name=scope_manager.get())
+            dict() if self.scope.get() is None else dict(name=self.scope.get())
         )
 
 

--- a/meeshkan/serve/admin/views.py
+++ b/meeshkan/serve/admin/views.py
@@ -4,9 +4,8 @@ import logging
 from tornado.web import RequestHandler
 
 from ..mock.rest import RestMiddlewareManager
-from ..mock.storage import StorageManager
 from ..mock.scope import scope_manager
-import json
+from ..mock.storage import StorageManager
 
 logger = logging.getLogger(__name__)
 

--- a/meeshkan/serve/admin/views.py
+++ b/meeshkan/serve/admin/views.py
@@ -4,6 +4,7 @@ from tornado.web import RequestHandler
 
 from ..mock.storage import storage_manager
 from ..mock.rest import rest_middleware_manager
+from ..mock.scope import scope_manager
 import json
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,19 @@ class StorageView(RequestHandler):
 
     def delete(self):
         storage_manager.clear()
+
+class ScopeView(RequestHandler):
+    SUPPORTED_METHODS = ["DELETE", "POST", "GET"]
+    
+    def delete(self):
+        scope_manager.clear()
+
+    def post(self):
+        scope_manager.set(self.get_body_argument("name"))
+    
+    def get(self):
+        self.set_header("Content-Type", 'application/json; charset="utf-8"')
+        return self.write(dict() if scope_manager.get() is None else dict(name=scope_manager.get()))
 
 
 class RestMiddlewaresView(RequestHandler):

--- a/meeshkan/serve/mock/scope.py
+++ b/meeshkan/serve/mock/scope.py
@@ -1,6 +1,7 @@
-import logging
-import requests
 import json
+import logging
+
+import requests
 
 logger = logging.getLogger(__name__)
 

--- a/meeshkan/serve/mock/scope.py
+++ b/meeshkan/serve/mock/scope.py
@@ -1,0 +1,21 @@
+import logging
+import requests
+import json
+
+logger = logging.getLogger(__name__)
+
+
+class ScopeManager:
+    def __init__(self):
+        self._name = None
+
+    def set(self, name):
+        self._name = name
+
+    def get(self):
+        return self._name
+
+    def clear(self):
+        self._name = None
+
+scope_manager = ScopeManager()

--- a/meeshkan/serve/mock/scope.py
+++ b/meeshkan/serve/mock/scope.py
@@ -6,7 +6,7 @@ import requests
 logger = logging.getLogger(__name__)
 
 
-class ScopeManager:
+class Scope:
     def __init__(self):
         self._name = None
 
@@ -18,6 +18,3 @@ class ScopeManager:
 
     def clear(self):
         self._name = None
-
-
-scope_manager = ScopeManager()

--- a/meeshkan/serve/mock/server.py
+++ b/meeshkan/serve/mock/server.py
@@ -12,6 +12,8 @@ from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.views import MockServerView
 from meeshkan.serve.utils.routing import PathRouting, Routing
 
+from .scope import Scope
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,17 +42,24 @@ def make_mocking_app(
 
 class MockServer:
     def __init__(
-        self, port, specs, callback_dir=None, admin_port=None, routing=PathRouting()
+        self,
+        port,
+        specs,
+        scope: Optional[Scope] = None,
+        callback_dir=None,
+        admin_port=None,
+        routing=PathRouting(),
     ):
         self._callback_dir = callback_dir
         self._admin_port = admin_port
         self._port = port
         self._specs = specs
         self._routing = routing
+        self._scope = scope or Scope()
 
     def run(self) -> None:
         if self._admin_port:
-            start_admin(self._admin_port)
+            start_admin(scope=self._scope, port=self._admin_port)
         app = make_mocking_app(self._callback_dir, self._specs, self._routing)
         http_server = HTTPServer(app)
         http_server.listen(self._port)

--- a/meeshkan/serve/record/proxy.py
+++ b/meeshkan/serve/record/proxy.py
@@ -62,6 +62,7 @@ class RecordProxyRunner:
         self._specs_dir = specs_dir
         self._routing = routing
         self._mode = mode
+
     def run(self):
 
         logger.info("Starting Meeshkan record on http://localhost:%s", self._port)

--- a/meeshkan/serve/record/proxy.py
+++ b/meeshkan/serve/record/proxy.py
@@ -1,9 +1,11 @@
 import logging
+from typing import Optional
 
 import tornado.ioloop
 from http_types import Request, Response
 
 from meeshkan.serve.admin.runner import start_admin
+from meeshkan.serve.mock.scope import Scope
 from meeshkan.serve.utils.data_callback import RequestLoggingCallback
 from meeshkan.serve.utils.routing import HeaderRouting
 
@@ -59,6 +61,7 @@ class RecordProxyRunner:
         port,
         log_dir,
         specs_dir,
+        scope: Optional[Scope] = None,
         routing=HeaderRouting(),
         mode=None,
         admin_port=None,
@@ -69,10 +72,11 @@ class RecordProxyRunner:
         self._routing = routing
         self._mode = mode
         self._admin_port = admin_port
+        self._scope = scope or Scope()
 
     def run(self):
         if self._admin_port:
-            start_admin(self._admin_port)
+            start_admin(scope=self._scope, port=self._admin_port)
 
         logger.info("Starting Meeshkan record on http://localhost:%s", self._port)
         logger.info(

--- a/tests/serve/admin/test_rest_middleware.py
+++ b/tests/serve/admin/test_rest_middleware.py
@@ -5,11 +5,14 @@ from tornado.httpclient import HTTPRequest
 
 from meeshkan.serve.admin import make_admin_app
 from meeshkan.serve.mock.rest import rest_middleware_manager
+from meeshkan.serve.mock.scope import Scope
+
+scope = Scope()
 
 
 @pytest.fixture
 def app():
-    return make_admin_app()
+    return make_admin_app(scope)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/serve/admin/test_scope.py
+++ b/tests/serve/admin/test_scope.py
@@ -1,10 +1,10 @@
+import json
+
+import pytest
 from tornado.httpclient import HTTPRequest
 
 from meeshkan.serve.admin import make_admin_app
 from meeshkan.serve.mock.scope import scope_manager
-
-import pytest
-import json
 
 
 @pytest.fixture

--- a/tests/serve/admin/test_scope.py
+++ b/tests/serve/admin/test_scope.py
@@ -1,0 +1,36 @@
+from tornado.httpclient import HTTPRequest
+
+from meeshkan.serve.admin import make_admin_app
+from meeshkan.serve.mock.scope import scope_manager
+
+import pytest
+import json
+
+
+@pytest.fixture
+def app():
+    return make_admin_app()
+
+
+@pytest.fixture(autouse=True)
+def setup():
+    yield True
+    scope_manager.clear()
+
+
+@pytest.mark.gen_test
+def test_admin_server_scope(http_client, base_url):
+    body = "name=foo"
+    req = HTTPRequest(base_url + "/admin/scope", method="POST", body=body, headers={'content-type': 'application/x-www-form-urlencoded', 'content-length': len(body)})
+    response = yield http_client.fetch(req)
+    assert response.code == 200
+    req = HTTPRequest(base_url + "/admin/scope")
+    response = yield http_client.fetch(req)
+    assert response.code == 200
+    assert json.loads(response.body)['name'] == 'foo'
+    req = HTTPRequest(base_url + "/admin/scope", method="DELETE")
+    yield http_client.fetch(req)
+    req = HTTPRequest(base_url + "/admin/scope")
+    response = yield http_client.fetch(req)
+    assert response.code == 200
+    assert not ('name' in json.loads(response.body))

--- a/tests/serve/admin/test_scope.py
+++ b/tests/serve/admin/test_scope.py
@@ -4,18 +4,20 @@ import pytest
 from tornado.httpclient import HTTPRequest
 
 from meeshkan.serve.admin import make_admin_app
-from meeshkan.serve.mock.scope import scope_manager
+from meeshkan.serve.mock.scope import Scope
+
+scope = Scope()
 
 
 @pytest.fixture
 def app():
-    return make_admin_app()
+    return make_admin_app(scope=scope)
 
 
 @pytest.fixture(autouse=True)
 def setup():
     yield True
-    scope_manager.clear()
+    scope.clear()
 
 
 @pytest.mark.gen_test

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,162 @@
+from meeshkan.build.builder import BASE_SCHEMA
+from meeshkan.__main__ import cli, _convert
+from meeshkan.config import DEFAULT_SPECS_DIR
+from click.testing import CliRunner
+from .util import read_recordings_as_strings
+from hamcrest import assert_that, has_key
+from pathlib import Path
+from typing import List
+import os
+from openapi_typed_2 import OpenAPIObject, convert_from_openapi
+import json
+import pkg_resources
+
+
+requests = read_recordings_as_strings()
+
+
+def write_input_file(target_file: str, requests: List[str]):
+    with open(target_file, "w") as f:
+        for request in requests:
+            f.write(request)
+
+
+def write_base_schema(target_file: str, schema: OpenAPIObject):
+    with open(target_file, "w") as f:
+        f.write(json.dumps(convert_from_openapi(schema)))
+
+
+def test_build_default_output_dir():
+    runner = CliRunner()
+
+    input_file = "input.jsonl"
+    base_schema = "openapi.yml"
+
+    with runner.isolated_filesystem():
+        # Prepare input file
+        write_input_file(input_file, requests)
+        write_base_schema(base_schema, BASE_SCHEMA)
+
+        runner_result = runner.invoke(
+            cli, ["build", "-i", input_file, "-a", base_schema, "--source", "file"]
+        )
+        assert (
+            runner_result.exit_code == 0
+        ), "Exited with code {}, expected zero".format(runner_result.exit_code)
+        expected_outputdir_path = Path(DEFAULT_SPECS_DIR)
+        assert expected_outputdir_path.is_dir(), "Output directory specs/ should exist"
+        with open(expected_outputdir_path.joinpath("openapi.json"), "r") as oai:
+            build_result = json.loads(oai.read())
+
+            # Verify result
+            assert_that(build_result, has_key("openapi"))
+
+
+def test_build_cmd():
+    """An uber test verifying build command input and output.
+    """
+    runner = CliRunner()
+
+    input_file = "input.jsonl"
+    base_schema = "openapi.yml"
+    output_directory = "out"
+
+    with runner.isolated_filesystem():
+        output_directory_path = Path(output_directory)
+        # Prepare input file
+        write_input_file(input_file, requests)
+        write_base_schema(base_schema, BASE_SCHEMA)
+
+        assert (
+            not output_directory_path.is_dir()
+        ), "Output directory {} should not exist yet".format(output_directory)
+
+        runner_result = runner.invoke(
+            cli,
+            [
+                "build",
+                "-i",
+                input_file,
+                "-o",
+                output_directory,
+                "-a",
+                base_schema,
+                "--source",
+                "file",
+            ],
+        )
+
+        assert (
+            runner_result.exit_code == 0
+        ), "Exited with code {}, expected zero".format(runner_result.exit_code)
+
+        assert (
+            output_directory_path.is_dir()
+        ), "Output directory {} should exist".format(output_directory_path.absolute)
+        with open(os.path.join(output_directory, "openapi.json"), "r") as oai:
+            build_result = json.loads(oai.read())
+
+            # Verify result
+            assert_that(build_result, has_key("openapi"))
+
+    assert runner_result.exit_code == 0
+    assert len(runner_result.output) == 0
+
+
+def test_convert_cmd():
+    runner = CliRunner()
+
+    # Absolute path, can be accessed in Click's "isolated filesystem"
+    input_file = Path("tests/convert/recordings/recordings.pcap").resolve()
+    output_file = "recordings.jsonl"
+
+    with runner.isolated_filesystem():
+
+        assert not Path(
+            output_file
+        ).is_file(), "Expected output file {} to not exist".format(output_file)
+
+        runner_result = runner.invoke(
+            cli, ["convert", "-i", str(input_file), "-o", output_file]
+        )
+
+        assert Path(output_file).is_file(), "Expected output file {} to exist".format(
+            output_file
+        )
+
+        assert runner_result.exit_code == 0
+
+
+######
+## TODO: these tests are basically identical, with the one below
+## only existing to get a more complete error log in case the one
+## above is broken.
+
+
+def test_convert_cmd_without_invocation():
+    runner = CliRunner()
+
+    # Absolute path, can be accessed in Click's "isolated filesystem"
+    input_file = Path("tests/convert/recordings/recordings.pcap").resolve()
+    output_file = "recordings.jsonl"
+
+    with runner.isolated_filesystem():
+
+        assert not Path(
+            output_file
+        ).is_file(), "Expected output file {} to not exist".format(output_file)
+
+        runner_result = _convert(str(input_file), output_file)
+
+        assert Path(output_file).is_file(), "Expected output file {} to exist".format(
+            output_file
+        )
+
+
+def test_version():
+    expected_version = pkg_resources.require("meeshkan")[0].version
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--version"])
+    assert result.exit_code == 0
+    assert result.output == f"cli, version {expected_version}\n"


### PR DESCRIPTION
Scope is a way to signal the current scope of the test.
For example, if we are testing A and then B, we set
the scope to A and then B, and by querying the scope, we can
assign API requests and responses to their logical "place"
in things like reports.