### PR TITLE
Log endpoints at startup

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -40,4 +40,4 @@ def start_admin(port):
     app = make_admin_app()
     http_server = HTTPServer(app)
     http_server.listen(port)
-    logger.info("Starting admin endpoint on http://localhost:%s/admin", port)
+    logger.info("⚙ Admin   http://localhost:%s/admin", port)

--- a/meeshkan/serve/commands.py
+++ b/meeshkan/serve/commands.py
@@ -5,14 +5,17 @@ import click
 
 IS_WINDOWS = os.name == "nt"
 
+from logging import getLogger
 from meeshkan.serve.mock.server import MockServer
 from .record.proxy import RecordProxyRunner
 from .utils.routing import PathRouting, HeaderRouting
 from ..build.update_mode import UpdateMode
 from ..config import DEFAULT_SPECS_DIR
+from .mock.specs import load_specs
 
 MOCK_PID = Path.home().joinpath(".meeshkan/mock.pid")
 RECORD_PID = Path.home().joinpath(".meeshkan/record.pid")
+logger = getLogger(__name__)
 
 
 def add_options(options):
@@ -78,11 +81,13 @@ def mock(ctx, callback_dir, admin_port, port, specs_dir, header_routing, daemon)
 @mock.command(name="start")  # type: ignore
 @add_options(_mock_options)
 def start_mock(callback_dir, admin_port, port, specs_dir, header_routing, daemon):
+    specs = load_specs(specs_dir)
+
     server = MockServer(
         callback_dir=callback_dir,
         admin_port=admin_port,
         port=port,
-        specs_dir=specs_dir,
+        specs=specs,
         routing=HeaderRouting() if header_routing else PathRouting(),
     )
 

--- a/meeshkan/serve/mock/matcher.py
+++ b/meeshkan/serve/mock/matcher.py
@@ -3,12 +3,14 @@ import lenses
 from lenses import lens
 import jsonschema
 from meeshkan.build.operation import operation_from_string
+from meeshkan.serve.mock.specs import OpenAPISpecification
 from dataclasses import replace
 import json
 import re
 from http_types import Request
 from typing import (
     cast,
+    List,
     Sequence,
     Tuple,
     TypeVar,
@@ -775,8 +777,8 @@ def truncate_path(path: str, o: OpenAPIObject, i: Request,) -> str:
 
 
 def match_request_to_openapi(
-    req: Request, r: Mapping[str, OpenAPIObject]
-) -> Mapping[str, OpenAPIObject]:
+    req: Request, specs: Sequence[OpenAPISpecification]
+) -> List[OpenAPISpecification]:
     def _path_item_modifier(oai: OpenAPIObject) -> Callable[[PathItem], PathItem]:
         def __path_item_modifier(path_item: PathItem) -> PathItem:
             return reduce(
@@ -809,10 +811,11 @@ def match_request_to_openapi(
             )
         )
 
-    return lens.Values().modify(_oai_modifier)(
+    d = lens.Values().modify(_oai_modifier)(
         {
-            k: v
-            for k, v in r.items()
-            if len(match_urls(req.protocol.value, req.host, v)) > 0
+            spec.source: spec.api
+            for spec in specs
+            if len(match_urls(req.protocol.value, req.host, spec.api)) > 0
         }
     )
+    return [OpenAPISpecification(api, source) for (source, api) in d.items()]

--- a/meeshkan/serve/mock/server.py
+++ b/meeshkan/serve/mock/server.py
@@ -1,12 +1,15 @@
 import logging
 from typing import Optional
 
+from typing import Sequence
+
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
 from tornado.web import Application
 
 from meeshkan.serve.admin.runner import start_admin
 from meeshkan.serve.mock.callbacks import CallbackManager, callback_manager
+from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.response_matcher import ResponseMatcher
 from meeshkan.serve.mock.views import MockServerView
 from meeshkan.serve.utils.routing import Routing, PathRouting
@@ -25,32 +28,57 @@ def make_mocking_app_(
     return Application([(r"/.*", MockServerView, dependencies)])
 
 
-def make_mocking_app(callback_dir: Optional[str], specs_dir: str, routing: Routing):
-
+def make_mocking_app(
+    callback_dir: Optional[str], specs: Sequence[OpenAPISpecification], routing: Routing
+):
     # callback_manager = CallbackManager()
     if callback_dir is not None:
         callback_manager.load(callback_dir)
 
-    response_matcher = ResponseMatcher(specs_dir)
+    response_matcher = ResponseMatcher(specs)
 
     return make_mocking_app_(callback_manager, response_matcher, routing)
 
 
 class MockServer:
     def __init__(
-        self, port, specs_dir, callback_dir=None, admin_port=None, routing=PathRouting()
+        self, port, specs, callback_dir=None, admin_port=None, routing=PathRouting()
     ):
         self._callback_dir = callback_dir
         self._admin_port = admin_port
         self._port = port
-        self._specs_dir = specs_dir
+        self._specs = specs
         self._routing = routing
 
-    def run(self):
+    def run(self) -> None:
         if self._admin_port:
             start_admin(self._admin_port)
-        app = make_mocking_app(self._callback_dir, self._specs_dir, self._routing)
+        app = make_mocking_app(self._callback_dir, self._specs, self._routing)
         http_server = HTTPServer(app)
         http_server.listen(self._port)
-        logger.info("Mock is listening on http://localhost:%s", self._port)
+        self.log_startup()
         IOLoop.current().start()
+
+    def log_startup(self) -> None:
+        for spec in self._specs:
+            if not spec.api.servers:
+                continue
+            for path, path_item in spec.api.paths.items():
+                for method in [
+                    "get",
+                    "put",
+                    "post",
+                    "delete",
+                    "options",
+                    "head",
+                    "patch",
+                    "trace",
+                ]:
+                    if getattr(path_item, method):
+                        logger.info(
+                            "→ "
+                            + method.upper().ljust(7)
+                            + f" http://localhost:{self._port}/"
+                            + spec.api.servers[0].url
+                            + path
+                        )

--- a/meeshkan/serve/mock/specs.py
+++ b/meeshkan/serve/mock/specs.py
@@ -1,0 +1,44 @@
+import os
+import logging
+from openapi_typed_2 import (
+    convert_to_openapi,
+    OpenAPIObject,
+)
+from typing import Sequence
+import json
+import yaml
+from dataclasses import dataclass
+
+
+@dataclass
+class OpenAPISpecification:
+    """An OpenAPI object with information about the source it was created from (such as the file name or URL)."""
+
+    api: OpenAPIObject
+    source: str
+
+
+def load_specs(specs_dir: str) -> Sequence[OpenAPISpecification]:
+    if not os.path.exists(specs_dir):
+        logging.info("OpenAPI schema directory not found %s", specs_dir)
+        return []
+    specs_with_sources = []
+    specs_paths = [
+        s
+        for s in os.listdir(specs_dir)
+        if s.endswith("yml") or s.endswith("yaml") or s.endswith("json")
+    ]
+    for spec_path in specs_paths:
+        full_spec_path = os.path.join(specs_dir, spec_path)
+        with open(full_spec_path, encoding="utf8") as spec_file:
+            specs_with_sources.append(
+                OpenAPISpecification(
+                    convert_to_openapi(
+                        (json.loads if spec_path.endswith("json") else yaml.safe_load)(
+                            spec_file.read()
+                        )
+                    ),
+                    spec_path,
+                )
+            )
+    return specs_with_sources

--- a/setup.py
+++ b/setup.py
@@ -225,6 +225,7 @@ setup(
     entry_points={"console_scripts": ENTRY_POINTS},
     cmdclass={
         "dist": BuildDistCommand,
+        "typecheck": TypeCheckCommand,
         "upload": UploadCommand,
         "test": TestCommand,
         "typecheck": TypeCheckCommand,

--- a/tests/serve/mock/end-to-end/opbank/test_opbank.py
+++ b/tests/serve/mock/end-to-end/opbank/test_opbank.py
@@ -4,6 +4,7 @@ import pytest
 import json
 
 from meeshkan.serve.mock.server import make_mocking_app
+from meeshkan.serve.mock.specs import load_specs
 from meeshkan.serve.utils.routing import HeaderRouting
 
 
@@ -11,7 +12,7 @@ from meeshkan.serve.utils.routing import HeaderRouting
 def app():
     return make_mocking_app(
         "tests/serve/mock/end-to-end/opbank/callbacks",
-        "tests/serve/mock/end-to-end/opbank/schemas",
+        load_specs("tests/serve/mock/end-to-end/opbank/schemas"),
         HeaderRouting(),
     )
 

--- a/tests/serve/mock/test_body_echoing.py
+++ b/tests/serve/mock/test_body_echoing.py
@@ -2,13 +2,16 @@ import pytest
 
 from meeshkan.serve.mock.server import make_mocking_app
 from meeshkan.serve.utils.routing import PathRouting
+from meeshkan.serve.mock.specs import load_specs
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 
 @pytest.fixture
 def app():
     return make_mocking_app(
-        "tests/serve/mock/callbacks", "tests/serve/mock/schemas/petstore", PathRouting()
+        "tests/serve/mock/callbacks",
+        load_specs("tests/serve/mock/schemas/petstore"),
+        PathRouting(),
     )
 
 

--- a/tests/serve/mock/test_control_via_rest.py
+++ b/tests/serve/mock/test_control_via_rest.py
@@ -6,6 +6,7 @@ from tornado.httpclient import HTTPRequest
 
 from meeshkan.serve.mock.rest import rest_middleware_manager
 from meeshkan.serve.mock.server import make_mocking_app
+from meeshkan.serve.mock.specs import load_specs
 from meeshkan.serve.utils.routing import HeaderRouting
 
 
@@ -13,7 +14,7 @@ from meeshkan.serve.utils.routing import HeaderRouting
 def app():
     return make_mocking_app(
         "tests/serve/mock/callbacks",
-        "tests/serve/mock/shemas/petstore",
+        load_specs("tests/serve/mock/shemas/petstore"),
         HeaderRouting(),
     )
 

--- a/tests/serve/mock/test_matcher.py
+++ b/tests/serve/mock/test_matcher.py
@@ -1,155 +1,177 @@
 from meeshkan.serve.mock.matcher import match_request_to_openapi
+from meeshkan.serve.mock.specs import OpenAPISpecification
 from openapi_typed_2 import OpenAPIObject, convert_to_openapi
 from http_types import RequestBuilder
-from typing import Dict
+from typing import Sequence
 import json
 
-store: Dict[str, OpenAPIObject] = {
-    "foo": convert_to_openapi(
-        {
-            "openapi": "",
-            "servers": [
-                {"url": "api.foo.com"}
-            ],  # we omit the protocol and it should still match
-            "info": {"title": "", "version": ""},
-            "paths": {
-                "/user": {
-                    "get": {"responses": {"200": {"description": "userget"}}},
-                    "post": {"responses": {"200": {"description": "userpost"}}},
-                    "description": "",
-                },
-                "/user/{id}": {
-                    "parameters": [
-                        {
-                            "name": "id",
-                            "in": "path",
-                            "required": True,
-                            "schema": {"type": "integer"},
-                        },
-                    ],
-                    "get": {"responses": {"200": {"description": "useridget"}}},
-                    "post": {"responses": {"201": {"description": "useridpost"}}},
-                },
-                "/user/{id}/name": {
-                    "get": {"responses": {"200": {"description": "useridnameget"}}},
-                    "post": {"responses": {"201": {"description": "useridnamepost"}}},
-                    "description": "",
-                },
-            },
-        }
-    ),
-    "bar": convert_to_openapi(
-        {
-            "openapi": "",
-            "servers": [{"url": "https://api.bar.com/v1"}],
-            "info": {"title": "", "version": ""},
-            "paths": {
-                "/guest": {
-                    "get": {"responses": {"200": {"description": "guestget"}}},
-                    "post": {"responses": {"200": {"description": "guestpost"}}},
-                    "description": "",
-                },
-                "/guest/{id}": {
-                    "get": {"responses": {"200": {"description": "guestidget"}}},
-                    "post": {"responses": {"201": {"description": "guestidpost"}}},
-                    "description": "",
-                },
-                "/guest/{id}/name": {
-                    "get": {"responses": {"200": {"description": "guestidnameget"}}},
-                    "post": {"responses": {"201": {"description": "guestidnamepost"}}},
-                    "description": "",
-                },
-            },
-        }
-    ),
-    "baz": convert_to_openapi(
-        {
-            "openapi": "",
-            "servers": [{"url": "https://api.baz.com"}],
-            "info": {"title": "", "version": ""},
-            "paths": {
-                "/guest": {
-                    "parameters": [
-                        {
-                            "in": "query",
-                            "required": True,
-                            "name": "hello",
-                            "schema": {"type": "string", "pattern": "^[0-9]+$"},
-                        },
-                    ],
-                    "get": {"responses": {"200": {"description": "guestget"}}},
-                    "post": {
+store: Sequence[OpenAPISpecification] = [
+    OpenAPISpecification(
+        convert_to_openapi(
+            {
+                "openapi": "",
+                "servers": [
+                    {"url": "api.foo.com"}
+                ],  # we omit the protocol and it should still match
+                "info": {"title": "", "version": ""},
+                "paths": {
+                    "/user": {
+                        "get": {"responses": {"200": {"description": "userget"}}},
+                        "post": {"responses": {"200": {"description": "userpost"}}},
+                        "description": "",
+                    },
+                    "/user/{id}": {
                         "parameters": [
                             {
-                                "in": "query",
+                                "name": "id",
+                                "in": "path",
                                 "required": True,
-                                "name": "thinking",
-                                "schema": {"type": "string"},
+                                "schema": {"type": "integer"},
                             },
                         ],
-                        "responses": {"200": {"description": "guestpost"}},
+                        "get": {"responses": {"200": {"description": "useridget"}}},
+                        "post": {"responses": {"201": {"description": "useridpost"}}},
                     },
-                    "description": "",
+                    "/user/{id}/name": {
+                        "get": {"responses": {"200": {"description": "useridnameget"}}},
+                        "post": {
+                            "responses": {"201": {"description": "useridnamepost"}}
+                        },
+                        "description": "",
+                    },
                 },
-                "/guest/{id}": {
-                    "parameters": [
-                        {
-                            "in": "query",
-                            "required": True,
-                            "name": "a",
-                            "schema": {"type": "string"},
+            }
+        ),
+        "foo",
+    ),
+    OpenAPISpecification(
+        convert_to_openapi(
+            {
+                "openapi": "",
+                "servers": [{"url": "https://api.bar.com/v1"}],
+                "info": {"title": "", "version": ""},
+                "paths": {
+                    "/guest": {
+                        "get": {"responses": {"200": {"description": "guestget"}}},
+                        "post": {"responses": {"200": {"description": "guestpost"}}},
+                        "description": "",
+                    },
+                    "/guest/{id}": {
+                        "get": {"responses": {"200": {"description": "guestidget"}}},
+                        "post": {"responses": {"201": {"description": "guestidpost"}}},
+                        "description": "",
+                    },
+                    "/guest/{id}/name": {
+                        "get": {
+                            "responses": {"200": {"description": "guestidnameget"}}
                         },
-                        {
-                            "in": "query",
-                            "required": True,
-                            "name": "b",
-                            "schema": {"type": "string"},
+                        "post": {
+                            "responses": {"201": {"description": "guestidnamepost"}}
                         },
-                        {"in": "query", "name": "c", "schema": {"type": "string"}},
-                    ],
-                    "get": {"responses": {"200": {"description": "guestidget"}}},
-                    "post": {
+                        "description": "",
+                    },
+                },
+            }
+        ),
+        "bar",
+    ),
+    OpenAPISpecification(
+        convert_to_openapi(
+            {
+                "openapi": "",
+                "servers": [{"url": "https://api.baz.com"}],
+                "info": {"title": "", "version": ""},
+                "paths": {
+                    "/guest": {
                         "parameters": [
                             {
-                                "in": "header",
+                                "in": "query",
                                 "required": True,
-                                "name": "zz",
+                                "name": "hello",
+                                "schema": {"type": "string", "pattern": "^[0-9]+$"},
+                            },
+                        ],
+                        "get": {"responses": {"200": {"description": "guestget"}}},
+                        "post": {
+                            "parameters": [
+                                {
+                                    "in": "query",
+                                    "required": True,
+                                    "name": "thinking",
+                                    "schema": {"type": "string"},
+                                },
+                            ],
+                            "responses": {"200": {"description": "guestpost"}},
+                        },
+                        "description": "",
+                    },
+                    "/guest/{id}": {
+                        "parameters": [
+                            {
+                                "in": "query",
+                                "required": True,
+                                "name": "a",
                                 "schema": {"type": "string"},
                             },
                             {
                                 "in": "query",
                                 "required": True,
-                                "name": "zzz",
+                                "name": "b",
                                 "schema": {"type": "string"},
                             },
                             {"in": "query", "name": "c", "schema": {"type": "string"}},
                         ],
-                        "responses": {"201": {"description": "guestidpost"}},
+                        "get": {"responses": {"200": {"description": "guestidget"}}},
+                        "post": {
+                            "parameters": [
+                                {
+                                    "in": "header",
+                                    "required": True,
+                                    "name": "zz",
+                                    "schema": {"type": "string"},
+                                },
+                                {
+                                    "in": "query",
+                                    "required": True,
+                                    "name": "zzz",
+                                    "schema": {"type": "string"},
+                                },
+                                {
+                                    "in": "query",
+                                    "name": "c",
+                                    "schema": {"type": "string"},
+                                },
+                            ],
+                            "responses": {"201": {"description": "guestidpost"}},
+                        },
+                        "description": "",
                     },
-                    "description": "",
-                },
-                "/guest/{id}/name": {
-                    "get": {"responses": {"200": {"description": "guestidnameget"}}},
-                    "post": {
-                        "requestBody": {
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "type": "object",
-                                        "required": ["age"],
-                                        "properties": {"age": {"type": "integer"}},
+                    "/guest/{id}/name": {
+                        "get": {
+                            "responses": {"200": {"description": "guestidnameget"}}
+                        },
+                        "post": {
+                            "requestBody": {
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "required": ["age"],
+                                            "properties": {"age": {"type": "integer"}},
+                                        },
                                     },
                                 },
                             },
+                            "responses": {"201": {"description": "guestidnamepost"}},
                         },
-                        "responses": {"201": {"description": "guestidnamepost"}},
+                        "description": "",
                     },
-                    "description": "",
                 },
-            },
-        }
+            }
+        ),
+        "baz",
     ),
-}
+]
 
 
 def test_matcher_1():
@@ -166,21 +188,24 @@ def test_matcher_1():
             }
         ),
         store,
-    ) == {
-        "foo": convert_to_openapi(
-            {
-                "openapi": "",
-                "servers": [{"url": "api.foo.com"}],
-                "info": {"title": "", "version": ""},
-                "paths": {
-                    "/user": {
-                        "get": {"responses": {"200": {"description": "userget"}}},
-                        "description": "",
+    ) == [
+        OpenAPISpecification(
+            convert_to_openapi(
+                {
+                    "openapi": "",
+                    "servers": [{"url": "api.foo.com"}],
+                    "info": {"title": "", "version": ""},
+                    "paths": {
+                        "/user": {
+                            "get": {"responses": {"200": {"description": "userget"}}},
+                            "description": "",
+                        },
                     },
-                },
-            }
-        ),
-    }
+                }
+            ),
+            "foo",
+        )
+    ]
 
 
 def test_matcher_2():
@@ -228,16 +253,19 @@ def test_matcher_3():
             }
         ),
         store,
-    ) == {
-        "foo": convert_to_openapi(
-            {
-                "openapi": "",
-                "servers": [{"url": "api.foo.com"}],
-                "info": {"title": "", "version": ""},
-                "paths": {},
-            }
+    ) == [
+        OpenAPISpecification(
+            convert_to_openapi(
+                {
+                    "openapi": "",
+                    "servers": [{"url": "api.foo.com"}],
+                    "info": {"title": "", "version": ""},
+                    "paths": {},
+                }
+            ),
+            "foo",
         )
-    }
+    ]
 
 
 def test_matcher_4():
@@ -254,28 +282,31 @@ def test_matcher_4():
             }
         ),
         store,
-    ) == {
-        "foo": convert_to_openapi(
-            {
-                "openapi": "",
-                "servers": [{"url": "api.foo.com"}],
-                "info": {"title": "", "version": ""},
-                "paths": {
-                    "/user/{id}": {
-                        "parameters": [
-                            {
-                                "name": "id",
-                                "in": "path",
-                                "required": True,
-                                "schema": {"type": "integer"},
-                            },
-                        ],
-                        "get": {"responses": {"200": {"description": "useridget"}}},
+    ) == [
+        OpenAPISpecification(
+            convert_to_openapi(
+                {
+                    "openapi": "",
+                    "servers": [{"url": "api.foo.com"}],
+                    "info": {"title": "", "version": ""},
+                    "paths": {
+                        "/user/{id}": {
+                            "parameters": [
+                                {
+                                    "name": "id",
+                                    "in": "path",
+                                    "required": True,
+                                    "schema": {"type": "integer"},
+                                },
+                            ],
+                            "get": {"responses": {"200": {"description": "useridget"}}},
+                        },
                     },
-                },
-            }
+                }
+            ),
+            "foo",
         ),
-    }
+    ]
 
 
 def test_matcher_5():
@@ -292,16 +323,19 @@ def test_matcher_5():
             }
         ),
         store,
-    ) == {
-        "foo": convert_to_openapi(
-            {
-                "openapi": "",
-                "servers": [{"url": "api.foo.com"}],
-                "info": {"title": "", "version": ""},
-                "paths": {},
-            }
-        ),
-    }
+    ) == [
+        OpenAPISpecification(
+            convert_to_openapi(
+                {
+                    "openapi": "",
+                    "servers": [{"url": "api.foo.com"}],
+                    "info": {"title": "", "version": ""},
+                    "paths": {},
+                }
+            ),
+            "foo",
+        )
+    ]
 
 
 def test_matcher_6():
@@ -318,16 +352,19 @@ def test_matcher_6():
             }
         ),
         store,
-    ) == {
-        "foo": convert_to_openapi(
-            {
-                "openapi": "",
-                "servers": [{"url": "api.foo.com"}],
-                "info": {"title": "", "version": ""},
-                "paths": {"/user": {"description": ""}},
-            }
-        ),
-    }
+    ) == [
+        OpenAPISpecification(
+            convert_to_openapi(
+                {
+                    "openapi": "",
+                    "servers": [{"url": "api.foo.com"}],
+                    "info": {"title": "", "version": ""},
+                    "paths": {"/user": {"description": ""}},
+                }
+            ),
+            "foo",
+        )
+    ]
 
 
 def test_matcher_7():
@@ -346,13 +383,15 @@ def test_matcher_7():
             ),
             store,
         )
-        == {}
+        == []
     )
 
 
 def test_matcher_8():
-    assert (
-        match_request_to_openapi(
+    (baz_spec,) = (spec for spec in store if spec.source == "baz")
+    (matched_spec,) = (
+        spec
+        for spec in match_request_to_openapi(
             RequestBuilder.from_dict(
                 {
                     "headers": {},
@@ -365,16 +404,16 @@ def test_matcher_8():
                 }
             ),
             store,
-        )["baz"]
-        .paths["/guest"]
-        .get
-        == store["baz"].paths["/guest"].get
+        )
+        if spec.source == "baz"
     )
+    assert matched_spec.api.paths["/guest"].get == baz_spec.api.paths["/guest"].get
 
 
 def test_matcher_9():
-    assert (
-        match_request_to_openapi(
+    (matched_spec,) = (
+        spec
+        for spec in match_request_to_openapi(
             RequestBuilder.from_dict(
                 {
                     "headers": {},
@@ -387,11 +426,10 @@ def test_matcher_9():
                 }
             ),
             store,
-        )["baz"]
-        .paths["/guest"]
-        .get
-        is None
+        )
+        if spec.source == "baz"
     )
+    assert matched_spec.api.paths["/guest"].get is None
 
 
 def test_matcher_10():
@@ -409,16 +447,18 @@ def test_matcher_10():
                 }
             ),
             store,
-        )["baz"]
-        .paths["/guest"]
+        )[0]
+        .api.paths["/guest"]
         .get
         is None
     )
 
 
 def test_matcher_11():
-    assert (
-        match_request_to_openapi(
+    (baz_spec,) = (spec for spec in store if spec.source == "baz")
+    (matched_spec,) = (
+        spec
+        for spec in match_request_to_openapi(
             RequestBuilder.from_dict(
                 {
                     "headers": {},
@@ -433,10 +473,12 @@ def test_matcher_11():
                 }
             ),
             store,
-        )["baz"]
-        .paths["/guest/{id}/name"]
-        .post
-        == store["baz"].paths["/guest/{id}/name"].post
+        )
+        if spec.source == "baz"
+    )
+    assert (
+        matched_spec.api.paths["/guest/{id}/name"].post
+        == baz_spec.api.paths["/guest/{id}/name"].post
     )
 
 
@@ -457,16 +499,18 @@ def test_matcher_12():
                 }
             ),
             store,
-        )["baz"]
-        .paths["/guest/{id}/name"]
+        )[0]
+        .api.paths["/guest/{id}/name"]
         .post
         is None
     )
 
 
 def test_matcher_13():
-    assert (
-        match_request_to_openapi(
+    (baz_spec,) = (spec for spec in store if spec.source == "baz")
+    (matched_spec,) = (
+        spec
+        for spec in match_request_to_openapi(
             RequestBuilder.from_dict(
                 {
                     "headers": {"zz": "top"},
@@ -479,10 +523,12 @@ def test_matcher_13():
                 }
             ),
             store,
-        )["baz"]
-        .paths["/guest/{id}"]
-        .post
-        == store["baz"].paths["/guest/{id}"].post
+        )
+        if spec.source == "baz"
+    )
+    assert (
+        matched_spec.api.paths["/guest/{id}"].post
+        == baz_spec.api.paths["/guest/{id}"].post
     )
 
 
@@ -501,8 +547,8 @@ def test_matcher_14():
                 }
             ),
             store,
-        )["baz"]
-        .paths["/guest/{id}"]
+        )[0]
+        .api.paths["/guest/{id}"]
         .post
         is None
     )
@@ -522,18 +568,23 @@ def test_matcher_15():
             }
         ),
         store,
-    ) == {
-        "bar": convert_to_openapi(
-            {
-                "openapi": "",
-                "servers": [{"url": "https://api.bar.com/v1"}],
-                "info": {"title": "", "version": ""},
-                "paths": {
-                    "/guest/{id}": {
-                        "post": {"responses": {"201": {"description": "guestidpost"}}},
-                        "description": "",
+    ) == [
+        OpenAPISpecification(
+            convert_to_openapi(
+                {
+                    "openapi": "",
+                    "servers": [{"url": "https://api.bar.com/v1"}],
+                    "info": {"title": "", "version": ""},
+                    "paths": {
+                        "/guest/{id}": {
+                            "post": {
+                                "responses": {"201": {"description": "guestidpost"}}
+                            },
+                            "description": "",
+                        },
                     },
-                },
-            }
+                }
+            ),
+            "baz",
         )
-    }
+    ]

--- a/tests/serve/mock/test_mocking_server_gen_petstore.py
+++ b/tests/serve/mock/test_mocking_server_gen_petstore.py
@@ -4,6 +4,7 @@ import pytest
 import json
 
 from meeshkan.serve.mock.server import make_mocking_app
+from meeshkan.serve.mock.specs import load_specs
 from meeshkan.serve.utils.routing import HeaderRouting
 
 
@@ -11,7 +12,7 @@ from meeshkan.serve.utils.routing import HeaderRouting
 def app():
     return make_mocking_app(
         "tests/serve/mock/callbacks",
-        "tests/serve/mock/schemas/petstore",
+        load_specs("tests/serve/mock/schemas/petstore"),
         HeaderRouting(),
     )
 

--- a/tests/serve/mock/test_mocking_server_gen_stripe.py
+++ b/tests/serve/mock/test_mocking_server_gen_stripe.py
@@ -3,13 +3,16 @@ import json
 import pytest
 
 from meeshkan.serve.mock.server import make_mocking_app
+from meeshkan.serve.mock.specs import load_specs
 from meeshkan.serve.utils.routing import HeaderRouting
 
 
 @pytest.fixture
 def app():
     return make_mocking_app(
-        "tests/serve/mock/callbacks", "tests/serve/mock/schemas/stripe", HeaderRouting()
+        "tests/serve/mock/callbacks",
+        load_specs("tests/serve/mock/schemas/stripe"),
+        HeaderRouting(),
     )
 
 

--- a/tests/serve/record/test_proxy.py
+++ b/tests/serve/record/test_proxy.py
@@ -6,6 +6,7 @@ import pytest
 from http_types import HttpMethod, Protocol
 from meeshkan.serve.record.proxy import RecordProxy
 from meeshkan.serve.mock.server import make_mocking_app
+from meeshkan.serve.mock.specs import load_specs
 from meeshkan.serve.utils.data_callback import DataCallback
 from meeshkan.serve.utils.routing import PathRouting, StaticRouting, HeaderRouting
 from tornado.httpclient import HTTPRequest
@@ -16,7 +17,7 @@ from tornado.testing import bind_unused_port
 def app():
     return make_mocking_app(
         "tests/serve/mock/callbacks",
-        "tests/serve/mock/schemas/petstore",
+        load_specs("tests/serve/mock/schemas/petstore"),
         StaticRouting("http://petstore.swagger.io"),
     )
 


### PR DESCRIPTION
Also introduce a `OpenAPISpecification` dataclass containing the API object and source information, instead of sending around a dict mapping from source to API object, and extract the loading of specs out from ResponseMatcher.

Current log output at startup:

```sh
$ meeshkan mock --specs-dir tests/serve/mock/schemas/petstore 
Starting admin endpoint on http://localhost:8888/admin
Mock is listening on http://localhost:8000
```

After this PR:

```sh
$ meeshkan mock --specs-dir tests/serve/mock/schemas/petstore 
⚙ Admin   http://localhost:8888/admin
→ GET     http://localhost:8000/http://petstore.swagger.io/pets
→ POST    http://localhost:8000/http://petstore.swagger.io/pets
→ GET     http://localhost:8000/http://petstore.swagger.io/pets/{petId}
```

In the future I think we should show an admin page at http://localhost:8888/admin, showing:
- The above list of endpoints.
- The OpenAPI specifications, allowing the API endpoints to be inspected and called from Swagger Editor.
- The documentation of the admin endpoints, and links to the meeshkan documentation.
