### PR TITLE
Remove the "Meeshkan CLI" sentence from --help

### DIFF
--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -31,9 +31,6 @@ def log(*args):
 @click.group()
 @click.version_option()
 def cli():
-    """
-    Meeshkan CLI.
-    """
     setup()  # Ensure setup is done before invoking the CLI.
 
 


### PR DESCRIPTION
The initial `--help` output should be as brief as possible and show information about using the tool itself.

In #121 we discussed improving our elevator pitch (one sentence summary). But after feedback from Nikolay and looking around at other tools, I don't think that belongs in the `--help` output, so we can probably just remove the `Meeshkan CLI` sentence completely.

Before this PR:

```sh
$ meeshkan --help
Usage: meeshkan [OPTIONS] COMMAND [ARGS]...

  Meeshkan CLI.

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  build    Build an OpenAPI specification from HTTP recordings.
  convert  Convert recordings from PCAP to JSONL format.
  mock     Run a mock server using OpenAPI specifications.
  record   Record HTTP traffic from a reverse proxy.
```

After this PR:

```sh
$ meeshkan --help
Usage: meeshkan [OPTIONS] COMMAND [ARGS]...

Options:
  --version  Show the version and exit.
  --help     Show this message and exit.

Commands:
  build    Build an OpenAPI specification from HTTP recordings.
  convert  Convert recordings from PCAP to JSONL format.
  mock     Run a mock server using OpenAPI specifications.
  record   Record HTTP traffic from a reverse proxy.
```