### PR TITLE
Docs: Polish initial impression of running Meeshkan

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Meeshkan is a tool that mocks HTTP APIs for use in sandboxes as well as for auto
   - [Automated builds](#automated-builds)
   - [Publishing Meeshkan as a PyPi package](#publishing-meeshkan-as-a-pypi-package)
 - [Contributing](#contributing)
+  - [Code of Conduct](#code-of-conduct)
 
 ## Installation
 Install via [pip](https://pip.pypa.io/en/stable/installing/) (requires **Python 3.6+**):
@@ -159,6 +160,8 @@ For more information about mocking, including adding custom middleware and modif
 
 Here are some useful tips for building and running Meeshkan from source. 
 
+If you run into any issues, please [reach out to our team on Gitter](https://gitter.im/Meeshkan/community).
+
 ### Getting started
 
 1. Clone this repository: `git clone https://github.com/meeshkan/meeshkan`
@@ -238,5 +241,7 @@ To see what the different commands do, see `Command` classes in [setup.py](https
 ## Contributing
 
 Thanks for your interest in contributing! Please take a look at our [development guide](#development) for notes on how to develop the package locally.  A great way to start contributing is to [file an issue](https://github.com/meeshkan/meeshkan/issue) or [make a pull request](https://github.com/meeshkan/meeshkan/pulls).
+
+### Code of Conduct
 
 Please note that this project is governed by the [Meeshkan Community Code of Conduct](https://github.com/Meeshkan/code-of-conduct). By participating, you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ For more information about recording, including direct file writing and kafka st
 Using the Meeshkan CLI, you can **build** an OpenAPI schema from a single `.jsonl` file, in addition to any existing OpenAPI specs that describe how your service works.
 
 ```bash
-$ pip install meeshkan # if not installed yet
 $ meeshkan build --input-file path/to/recordings.jsonl 
 ```
 
@@ -149,8 +148,10 @@ For more information about building, including mixing together the two modes and
 You can use an OpenAPI spec, such as the one created with `meeshkan build`, to create a **mock** server using Meeshkan.
 
 ```bash
-$ meeshkan mock
+$ meeshkan mock path/to/dir/
 ```
+
+_Note: You can specify a path to the directory your OpenAPI spec is in or a path to one specific file._
 
 For more information about mocking, including adding custom middleware and modifying the mocking schema JIT via an admin API, see the [mocking documentation](./docs/MOCK.md).
 

--- a/README.md
+++ b/README.md
@@ -100,13 +100,15 @@ To record API traffic, the Meeshkan CLI provides a `record` mode that captures A
 $ meeshkan record
 ```
 
-This starts Meeshkan as a reverse proxy on the default port of `8000`.  For example, with curl, you can use Meeshkan as a proxy like so:
+This starts Meeshkan as a reverse proxy on the default port of `8000` and creates two directories: `logs` and `specs`. 
+
+For example, with [curl](https://curl.haxx.se/), you can use Meeshkan as a proxy like so:
 
 ```bash
 $ curl http://localhost:8000/http://api.example.com
 ```
 
-By default, the recording proxy treats the path as the target URL and writes a [`.jsonl`](https://jsonlines.org) file containing logs of all server traffic to a `logs` directory.  All logs are created in the [`http-types`](https://github.com/meeshkan/http-types) format.  The `meeshkan build` tool expects all recordings to be represented in a `.jsonl` file containing recordings represented in the `http-types` format.
+By default, the recording proxy treats the path as the target URL and writes a [`.jsonl`](https://jsonlines.org) file containing logs of all server traffic to the `logs` directory.  All logs are created in the [`http-types`](https://github.com/meeshkan/http-types) format.  The `meeshkan build` tool expects all recordings to be represented in a `.jsonl` file containing recordings represented in the `http-types` format.
 
 For more information about recording, including direct file writing and kafka streaming, see the [recording documentation](./docs/RECORD.md).
 
@@ -115,23 +117,26 @@ For more information about recording, including direct file writing and kafka st
 Using the Meeshkan CLI, you can **build** an OpenAPI schema from a single `.jsonl` file, in addition to any existing OpenAPI specs that describe how a service works.
 
 ```bash
-$ meeshkan build -i path/to/recordings.jsonl [-o path/to/output_directory]
+$ pip install meeshkan # if not installed yet
+$ meeshkan build --input-file path/to/recordings.jsonl 
 ```
 
 The input file should be in [JSON Lines](http://jsonlines.org/) format and every line should be in [http-types](https://meeshkan.github.io/http-types/) JSON format. 
 
 For an example input file, see [recordings.jsonl](https://github.com/Meeshkan/meeshkan/blob/master/resources/recordings.jsonl). The libraries listed at [http-types](https://meeshkan.github.io/http-types/) can be used to generate input files in your language of choice.
 
-Use dash (`-i -`) to read from standard input:
+Optionally, you can also specify an output directory using the `--out` flag followed by the path to this directory. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory. 
+
+Use dash (`--input-file -`) to read from standard input:
 
 ```bash
-$ meeshkan build -i - < recordings.jsonl
+$ meeshkan build --input-file - < recordings.jsonl
 ```
 ### Building modes
 You can use a mode flag to indicate how the OpenAPI spec should be built, for example:
 
 ```bash
-meeshkan build -i path/to/recordings.jsonl --mode gen
+meeshkan build --input-file path/to/recordings.jsonl --mode gen
 ```
 
 Supported modes are:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $ apt update && apt-get install meeshkan
 ## Getting started with Meeshkan
 
 The basic Meeshkan flow is **collect, build and mock.**
-1. To start, **collect** data from recorded server traffic and/or OpenAPI specs.
+1. First, **collect** data from recorded server traffic and/or OpenAPI specs.
 1. Then, **build** a schema that unifies these various data sources.
 1. Finally, use this schema to create a **mock** server of an API.
 
@@ -101,30 +101,28 @@ To record API traffic, the Meeshkan CLI provides a `record` mode that captures A
 $ meeshkan record
 ```
 
-This starts Meeshkan as a reverse proxy on the default port of `8000` and creates two directories: `logs` and `specs`. 
+This command starts Meeshkan as a reverse proxy on the default port of `8000` and creates two directories: `logs` and `specs`. 
 
-For example, with [curl](https://curl.haxx.se/), you can use Meeshkan as a proxy like so:
+With [curl](https://curl.haxx.se/), for example, you can use Meeshkan as a proxy like so:
 
 ```bash
 $ curl http://localhost:8000/http://api.example.com
 ```
 
-By default, the recording proxy treats the path as the target URL and writes a [`.jsonl`](https://jsonlines.org) file containing logs of all server traffic to the `logs` directory.  All logs are created in the [`http-types`](https://github.com/meeshkan/http-types) format.  The `meeshkan build` tool expects all recordings to be represented in a `.jsonl` file containing recordings represented in the `http-types` format.
+By default, the recording proxy treats the path as the target URL. It then writes a [`.jsonl`](https://jsonlines.org) file containing logs of all server traffic to the `logs` directory.  All logs are created in the [`http-types`](https://github.com/meeshkan/http-types) format. This is because Meeshkan's `build` tool expects all recordings to be represented in a `.jsonl` file containing recordings represented in the `http-types` format.
 
 For more information about recording, including direct file writing and kafka streaming, see the [recording documentation](./docs/RECORD.md).
 
 ## Build a Meeshkan spec from recordings
 
-Using the Meeshkan CLI, you can **build** an OpenAPI schema from a single `.jsonl` file, in addition to any existing OpenAPI specs that describe how a service works.
+Using the Meeshkan CLI, you can **build** an OpenAPI schema from a single `.jsonl` file, in addition to any existing OpenAPI specs that describe how your service works.
 
 ```bash
 $ pip install meeshkan # if not installed yet
 $ meeshkan build --input-file path/to/recordings.jsonl 
 ```
 
-The input file should be in [JSON Lines](http://jsonlines.org/) format and every line should be in [http-types](https://meeshkan.github.io/http-types/) JSON format. 
-
-For an example input file, see [recordings.jsonl](https://github.com/Meeshkan/meeshkan/blob/master/resources/recordings.jsonl). The libraries listed at [http-types](https://meeshkan.github.io/http-types/) can be used to generate input files in your language of choice.
+_Note: The input file should be in [JSON Lines](http://jsonlines.org/) format and every line should be in [http-types](https://meeshkan.github.io/http-types/) JSON format. For an example input file, see [recordings.jsonl](./resources/recordings.jsonl)._
 
 Optionally, you can also specify an output directory using the `--out` flag followed by the path to this directory. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory. 
 
@@ -230,13 +228,13 @@ Configuration for CircleCI [build pipeline](https://app.circleci.com/github/Mees
 
 ### Publishing Meeshkan as a PyPi package
 
-To publish Meeshkan as a PyPi package, please do the following steps:
+To publish Meeshkan as a PyPi package, complete the following steps:
 
 1. Bump the version in [setup.py](https://github.com/Meeshkan/meeshkan/tree/master/setup.py) if the version is the same as in the published [package](https://pypi.org/project/meeshkan/). Commit and push.
-1. Run `python setup.py test`, `python setup.py typecheck` and `python setup.py dist` to check everything works
+1. Run `python setup.py test` to check that everything works
 1. To build and upload the package, run `python setup.py upload`. Insert PyPI credentials to upload the package to `PyPI`. The command will also run `git tag` to tag the commit as a release and push the tags to remote.
 
-To see what the different commands do, see `Command` classes in [setup.py](https://github.com/Meeshkan/meeshkan/tree/master/setup.py).
+> To see what the different commands do, see `Command` classes in [setup.py](https://github.com/Meeshkan/meeshkan/tree/master/setup.py).
 
 ## Contributing
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,8 +1,8 @@
 # Building with Meeshkan
 
 Meeshkan builds OpenAPI specs from two possible sources:
+- Recordings of HTTP API traffic serialized in the [`http-types`](https://github.com/meeshkan/http-types) format and written to a [`.jsonl`](https://jsonlines.org) file
 - Other OpenAPI specs
-- Recordings of HTTP API traffic serialized in the [`http-types`](https://github.com/meeshkan/http-types) format and written to a [`.jsonl`](https://jsonlines.org) file.
 
 In case one only has an OpenAPI spec and no server recodings, it is not necessary to run Meeshkan build and you can go directly to the [`meeshkan mock`](./MOCK.md) command.
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -6,21 +6,56 @@ Meeshkan builds OpenAPI specs from two possible sources:
 
 In case one only has an OpenAPI spec and no server recodings, it is not necessary to run Meeshkan build and you can go directly to the [`meeshkan mock`](./MOCK.md) command.
 
-## The meeshkan build command
+## What's in this document
 
-To build an OpenAPI spec from recorded HTTP API traffic and other OpenAPI specs, use the `meeshkan build` command.
+- [The `meeshkan build` command](#the-meeshkan-build-command)
+    - [Building a spec from recorded HTTP API traffic](#building-a-spec-from-recorded-http-api-traffic)
+    - [Building a spec from both recorded traffic and other OpenAPI specs](#building-a-spec-from-both-recorded-traffic-and-other-openapi-specs)
+- [`gen` vs. `replay` mode](#gen-vs-replay-mode)
+    - [`gen` mode](#gen-mode)
+    - [`replay` mode](#replay-mode)
+- [Editing and merging specs](#editing-and-merging-specs)
+- [Next up: Mocking with Meeshkan](#next-up-mocking-with-meeshkan)
 
-```sh
-$ meeshkan build -i my_recoding.jsonl -a my_openapi_spec.yml -o result/
+## The `meeshkan build` command
+
+⚠️ Before getting started, you should make sure that any recorded HTTP API traffic that you'll use is in the correct format. The `meeshkan build` command expects that recordings are in a single [JSON Lines](http://jsonlines.org/) file and every line should be in the [http-types](https://meeshkan.github.io/http-types/) JSON format.
+
+For an example input file, see [recordings.jsonl](https://github.com/Meeshkan/meeshkan/blob/master/resources/recordings.jsonl). The libraries listed at [http-types](https://meeshkan.github.io/http-types/) can be used to generate input files in your language of choice.
+
+### Building a spec from recorded HTTP API traffic
+
+Once you've ensured that your files are formatted correctly, use the `meeshkan build` command to build an OpenAPI schema from your `.jsonl` file:
+
+```bash
+$ pip install meeshkan # if not installed yet
+$ meeshkan build --input-file path/to/recordings.jsonl 
 ```
 
-The above command will blend `my_recording.jsonl` and `my_openapi_spec.yml` into a unified OpenAPI spec stored in `result/openapi.yml`.
+Optionally, you can also specify an output directory using the `--out` flag followed by the path to this directory. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory. 
 
-## Gen mode versus replay mode
+> Note: More options for the `meeshkan build` command an be seen by running `meeshkan build --help`.
 
-Meeshkan can build OpenAPI specs in two different modes: `gen` and `replay`.  The default mode is `gen`, and the `-m` flag controls which mode is used.
+###  Building a spec from both recorded traffic and other OpenAPI specs
 
-# gen mode
+To build an OpenAPI spec from recorded HTTP API traffic and other OpenAPI specs, use the `meeshkan build` command with a few extra flags:
+
+```
+$ pip install meeshkan # if not installed yet
+$ meeshkan build --input-file pokeapi.co-recodings.jsonl --initial-openapi-spec my_openapi_spec.yml --out result/
+```
+
+The above command specifies recordings from the Pokemon API (`pokeapi.co-recodings.jsonl`) as the input file. Then, it blends those recordings with the designated initial spec (`my_openapi_spec.yml`) to create a unified OpenAPI specification. This specification is stored in `result/openapi.yml`.
+
+Designating an output directory (like with `result/` in the previous example) is optional. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory.
+
+> Note: More options for the `meeshkan build` command an be seen by running `meeshkan build --help`.
+
+## `gen` vs. `replay` mode
+
+Meeshkan can build OpenAPI specs in two different modes: `gen` and `replay`.  The default mode is `gen`, and the `--mode` flag controls which mode is used.
+
+### `gen` mode
 
 When `meeshkan build` runs in gen mode, it _infers_ the topology of an OpenAPI spec from recorded server traffic. For example, let's say that https://myapi.com returns the following three JSON objects.
 
@@ -55,7 +90,7 @@ Meeshkan will induce that the schema for a `200` resposne from `GET /uses/{id}` 
 
 We call this `gen` mode because it can be used to generate synthetic data from types. For example, when testing an API, `meeshkan mock` will serve synthetic data based on this spec.  A user will always have an integer id greater than 0, a name that is a first name, and may have an age between 0 and 200.
 
-# replay mode
+### `replay` mode
 
 Alternatively, `replay` mode will serve back rote fixtures recorded from the API.  Using one of the API calls as above, let's examine the spec that Meeshkan produces in replay mode.
 
@@ -76,6 +111,8 @@ Meeshkan will build a schema that contains the exact response received as a `200
   "required": ["id", "name"]
 }
 ```
+
+<!-- TODO: Mixed mode docs -->
 
 ## Editing and merging specs
 
@@ -98,3 +135,9 @@ with open('replay/openapi.json', 'r') as replay_file:
         with open('both/openapi.json', 'w') as both_file:
             both_file.write(json.dumps(convert_from_openapi(new), indent=2))
 ```
+
+## Next up: Mocking with Meeshkan
+
+Once you've generated an OpenAPI specification with `meeshkan build`, you can use that spec to create a mock server using Meeshkan.
+
+To learn how, visit our [mocking documentation](./docs/MOCK.md).

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -28,7 +28,6 @@ For an example input file, see [recordings.jsonl](https://github.com/Meeshkan/me
 Once you've ensured that your files are formatted correctly, use the `meeshkan build` command to build an OpenAPI schema from your `.jsonl` file:
 
 ```bash
-$ pip install meeshkan # if not installed yet
 $ meeshkan build --input-file path/to/recordings.jsonl 
 ```
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -32,13 +32,13 @@ $ pip install meeshkan # if not installed yet
 $ meeshkan build --input-file path/to/recordings.jsonl 
 ```
 
-Optionally, you can also specify an output directory using the `--out` flag followed by the path to this directory. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory. 
+Optionally, you can also specify an output directory using the `--out` flag followed by the path to this directory. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory. If you used `meeshkan record` to record your API traffic, the `specs` directory was created automatically. 
 
-> Note: More options for the `meeshkan build` command an be seen by running `meeshkan build --help`.
+> More options for the `meeshkan build` command an be seen by running `meeshkan build --help`.
 
-###  Building a spec from both recorded traffic and other OpenAPI specs
+### Building a spec from both recorded traffic and other OpenAPI specs
 
-To build an OpenAPI spec from recorded HTTP API traffic and other OpenAPI specs, use the `meeshkan build` command with a few extra flags:
+To build an OpenAPI spec from recorded HTTP API traffic and other OpenAPI specs, you can use the `meeshkan build` command with a few extra flags:
 
 ```
 $ pip install meeshkan # if not installed yet
@@ -47,17 +47,17 @@ $ meeshkan build --input-file pokeapi.co-recodings.jsonl --initial-openapi-spec 
 
 The above command specifies recordings from the Pokemon API (`pokeapi.co-recodings.jsonl`) as the input file. Then, it blends those recordings with the designated initial spec (`my_openapi_spec.yml`) to create a unified OpenAPI specification. This specification is stored in `result/openapi.yml`.
 
-Designating an output directory (like with `result/` in the previous example) is optional. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory.
+Designating an output directory (like with `result/` in the previous example) is optional. By default, Meeshkan will build the new OpenAPI specifications in the `specs` directory. If you used `meeshkan record` to record any API traffic, this `specs` directory was created automatically.
 
-> Note: More options for the `meeshkan build` command an be seen by running `meeshkan build --help`.
+> More options for the `meeshkan build` command an be seen by running `meeshkan build --help`.
 
 ## `gen` vs. `replay` mode
 
-Meeshkan can build OpenAPI specs in two different modes: `gen` and `replay`.  The default mode is `gen`, and the `--mode` flag controls which mode is used.
+Meeshkan can build OpenAPI specs in two different modes: `gen` and `replay`.  The default is `gen`, but you can use the `--mode` flag to control which mode is used.
 
 ### `gen` mode
 
-When `meeshkan build` runs in gen mode, it _infers_ the topology of an OpenAPI spec from recorded server traffic. For example, let's say that https://myapi.com returns the following three JSON objects.
+When `meeshkan build` runs in `gen` mode, it _infers_ the topology of an OpenAPI spec from recorded server traffic. For example, let's say that `https://myapi.com` returns the following three JSON objects:
 
 `https://myapi.com/users/3`
 ```json
@@ -74,7 +74,7 @@ When `meeshkan build` runs in gen mode, it _infers_ the topology of an OpenAPI s
 { "id": 5, "name": "Sven", "age": 96 }
 ```
 
-Meeshkan will induce that the schema for a `200` resposne from `GET /uses/{id}` should resemble the following.
+Meeshkan will induce that the schema for a `200` response from `GET /uses/{id}` should resemble the following:
 
 ```json
 {
@@ -87,19 +87,18 @@ Meeshkan will induce that the schema for a `200` resposne from `GET /uses/{id}` 
   "required": ["id", "name"]
 }
 ```
-
-We call this `gen` mode because it can be used to generate synthetic data from types. For example, when testing an API, `meeshkan mock` will serve synthetic data based on this spec.  A user will always have an integer id greater than 0, a name that is a first name, and may have an age between 0 and 200.
+We call this `gen` mode because it can be used to generate synthetic data from types. For example, when testing an API, `meeshkan mock` will serve synthetic data based on this spec. Using the previous response example, we can see that a user will always have an integer `id` greater than 0, a `name` that is a first name, and may have an `age` between 0 and 200.  
 
 ### `replay` mode
 
-Alternatively, `replay` mode will serve back rote fixtures recorded from the API.  Using one of the API calls as above, let's examine the spec that Meeshkan produces in replay mode.
+Alternatively, `replay` mode will serve back rote fixtures recorded from the API. The following API call, let's examine the spec that Meeshkan produces in `replay` mode.
 
 `https://myapi.com/users/3`
 ```json
 { "id": 3, "name": "Helga" }
 ```
 
-Meeshkan will build a schema that contains the exact response received as a `200` resposne from `GET /uses/3`.
+Meeshkan will build a schema that contains the exact response received as a `200` response from `GET /uses/3`.
 
 ```json
 {
@@ -116,7 +115,9 @@ Meeshkan will build a schema that contains the exact response received as a `200
 
 ## Editing and merging specs
 
-Because Meeshkan writes specs in the OpenAPI format, one can use an OpenAPI manipulation tool or library to edit and blend OpenAPI specs.  We'll show one example using [`openapi_typed_2`](https://github.com/meeshkan/openapi_typed_2) to blend together the paths from two different API specs and write a new spec.
+Because Meeshkan writes specs in the OpenAPI format, you can use an OpenAPI manipulation tool or library to edit and blend OpenAPI specs. 
+
+Let's look at one example using [`openapi_typed_2`](https://github.com/meeshkan/openapi_typed_2) to blend together the paths from two different API specs and then write a new spec.
 
 ```python
 from openapi_typed_2 import convert_to_openapi, convert_from_openapi

--- a/docs/MOCK.md
+++ b/docs/MOCK.md
@@ -2,7 +2,15 @@
 
 Meeshkan can be used to create a mock server from OpenAPI specifications and optional custom callback scripts.
 
-## The meeshkan mock command
+## What's in this document
+
+- [The `meeshkan mock` command](#the-meeshkan-mock-command)
+- [Daemon mode](#daemon-mode)
+- [Callbacks](#callbacks)
+- [Admin server](#admin-server)
+- [JIT OpenAPI schema manipulations](#jit-openapi-schema-manipulations)
+
+## The `meeshkan mock` command
 
 To create a mock server from an OpenAPI spec, use the `meeshkan mock` command.
 
@@ -10,13 +18,15 @@ To create a mock server from an OpenAPI spec, use the `meeshkan mock` command.
 $ meeshkan mock spec/dir/or/file
 ```
 
-And then, in another terminal window, type:
+> Note: The `--specs-dir` flag is telling Meeshkan to search for our OpenAPI spec inside the `specs` directory.
+
+Keep this running. Then, in another terminal window, type:
 
 ```bash
 $ curl http://localhost:8000/https://my.api.com/foo
 ```
 
-Assuming that the directory `spec_dir/` contains an OpenAPI spec with the server `https://my.api.com`, it will return a mock of the resource `GET /foo`.
+Assuming that the directory `specs` contains an OpenAPI spec with the server `https://my.api.com`, this will return a mock of the resource `GET /foo`.
 
 More options for the `meeshkan mock` command an be seen by running `meeshkan mock --help`.
 
@@ -88,7 +98,7 @@ def counter_callback(request_body, response_body, storage):
                                 headers={'x-custom-header': 'some value'})
 ```
 
-### Admin server
+## Admin server
 
 An admin server exists at the http://[host]:[admin_port]/admin endpoint. It can be used to reset the callback storage by calling `DELETE http://[host]:[admin_port]/admin/storage`.
 

--- a/docs/MOCK.md
+++ b/docs/MOCK.md
@@ -7,6 +7,9 @@ Meeshkan can be used to create a mock server from OpenAPI specifications and opt
 - [The `meeshkan mock` command](#the-meeshkan-mock-command)
 - [Daemon mode](#daemon-mode)
 - [Callbacks](#callbacks)
+    - [Function arguments](#function-arguments)
+    - [Formats](#formats)
+    - [Response types](#response-types)
 - [Admin server](#admin-server)
 - [JIT OpenAPI schema manipulations](#jit-openapi-schema-manipulations)
 
@@ -18,34 +21,41 @@ To create a mock server from an OpenAPI spec, use the `meeshkan mock` command.
 $ meeshkan mock spec/dir/or/file
 ```
 
-> Note: The `--specs-dir` flag is telling Meeshkan to search for our OpenAPI spec inside the `specs` directory.
+_Note: The `--specs-dir` flag is telling Meeshkan to search for the OpenAPI spec inside the `specs` directory._
 
-Keep this running. Then, in another terminal window, type:
+Keep this running. Then, in another terminal window, make a request using [curl](https://curl.haxx.se/):
 
 ```bash
-$ curl http://localhost:8000/https://my.api.com/foo
+$ curl http://localhost:8000/https://my.api.com/users
 ```
 
-Assuming that the directory `specs` contains an OpenAPI spec with the server `https://my.api.com`, this will return a mock of the resource `GET /foo`.
+Assuming that the directory `specs` contains an OpenAPI spec with the server `https://my.api.com`, this will return a mock of the resource `GET /users`.
 
-More options for the `meeshkan mock` command an be seen by running `meeshkan mock --help`.
+> More options for the `meeshkan mock` command an be seen by running `meeshkan mock --help`.
 
 ## Daemon mode
-Meeshkan can be launched as a daemon by providing -d command-line argument:
+
+Meeshkan can be launched as a [daemon](https://docs.docker.com/engine/reference/commandline/dockerd/) by providing the `--daemon` flag to the `meeshkan mock` command:
+
 ```bash
-$ meeshkan mock -d
+$ meeshkan mock --daemon
 ```
 
-All other command line arguments stay the same.
+_Note: All other command line arguments stay the same._
 
-To stop meeshkan daemon run:
+To stop your Meeshkan daemon, run:
+
 ```bash
 $ meeshkan mock --kill
 ```
 
 ## Callbacks
 
-To customize responses a directory containing callbacks can be provided in the `callback-dir` argument.
+To customize responses, a directory containing callbacks can be provided with the `--callback_path` flag:
+
+```bash
+$ meeshkan mock --callback_path path/to/directory
+```
 
 This directory can contain multiple Python scripts containing callbacks. A callback is a function decorated as 
 `meeshkan_server.server.callbacks.callback`, each being mapped to an endpoint by a HTTP method, host and path.
@@ -63,21 +73,26 @@ def counter_callback(request_body, response_body, storage):
     return response_body
 ```
 
-You may declare callbacks with following function arguments:
-* query 
-* request_headers
-* respone_headers
-* request
-* response
-* storage
-* request_body
-* response_body
+### Function arguments
 
-The will be wired automatically.    
+You can declare callbacks with following function arguments:
+* `query` 
+* `request_headers`
+* `respone_headers`
+* `request`
+* `response`
+* `storage`
+* `request_body`
+* `response_body`
 
-Storage is global storage that follows dict syntax. It can storage a global state shared across different endpoints.
+These function arguments will be wired automatically.    
 
-You may also provide a format to a callback decorator. The default format is 'json'. If you provide 'text' you'll get strings in request_body and response_body.
+_Note: `storage` is global storage that follows dict syntax. It can storage a global state shared across different endpoints._
+
+### Formats
+
+You may also provide a `format` to a callback decorator. The default `format` is `'json'`. But, for example, if you provide `'text'` you'll get strings in request_body and response_body:
+
 ```python
 from meeshkan.server.server.callbacks import callback
 
@@ -86,8 +101,11 @@ def counter_callback(request_body, response_body, storage):
     response_body = 'Response body should be a string'
     return response_body
 ```
-If you have to modify response headers you may provide response type value 'full'. In that case callback should return
-full http_types.Response structure instead of body.
+
+### Response types
+
+If you have to modify response headers, you can provide a `response` type value of `'full'`. In that case, the callback should return the full `http_types.Response` structure instead of body.
+
 ```python
 from meeshkan.server.server.callbacks import callback
 from http_types import Response
@@ -100,13 +118,21 @@ def counter_callback(request_body, response_body, storage):
 
 ## Admin server
 
-An admin server exists at the http://[host]:[admin_port]/admin endpoint. It can be used to reset the callback storage by calling `DELETE http://[host]:[admin_port]/admin/storage`.
+An admin server exists at the `http://[host]:[admin_port]/admin endpoint`. 
+
+It can be used to reset the callback storage by calling `DELETE http://[host]:[admin_port]/admin/storage`.
 
 ## JIT OpenAPI schema manipulations
 
-By default, `meeshkan mock` will serve random data based on the full range of possible outcomes specified in an OpenAPI spec. For example, if an endpoint can serve `200` and `403` responses, Meeshkan will randomly choose between the two.  Sometimes, this type of unpredictability is what you want, ie when doing a smoke test or end-to-end test.  However, other times, you would like to mock a more specific scenario.  For example, you may want an endpoint to _only_ serve 403, or _always_ omit an optional field in a `200` response.
+By default, `meeshkan mock` will serve random data based on the full range of possible outcomes specified in an OpenAPI spec. For example, if an endpoint can serve `200` and `403` responses, Meeshkan will randomly choose between the two. 
 
-To achieve this, Meeshkan provides a webhook API that will send the incoming request represented using the `http-types` format and the OpenAPI scheams in dictionary format to an endpoint and use the response from the endpoint as the final schema for mocking.  Here is the API for getting, setting, and deleting webhooks.
+Sometimes, this type of unpredictability is what you want. For instance, when doing a smoke test or end-to-end test. 
+
+However, other times, you would like to mock a more specific scenario. For example, you may want an endpoint to _only_ serve 403, or _always_ omit an optional field in a `200` response.
+
+To achieve this, Meeshkan provides a webhook API that will send the incoming request represented using the [`http-types`](https://github.com/meeshkan/http-types/) format and the OpenAPI scheams in dictionary format to an endpoint. Then, it will use the response from the endpoint as the final schema for mocking. 
+
+Here is the API for getting, setting, and deleting webhooks:
 
 | Method | Path | Description |
 | ------ | ---- | ----------- |
@@ -115,7 +141,7 @@ To achieve this, Meeshkan provides a webhook API that will send the incoming req
 | `GET` | `/admin/middleware/rest/pregen` | Get all webhooks that have been registered. |
 | `DELETE` | `/admin/middleware/rest/pregen` | Delete all registered webhooks. |
 
-The webhook must accept a `POST` request for an object in the following format:
+The webhook must accept a `POST` request for an object in the following format. Then, it should return the `schemas` object - that is, a dictionary of OpenAPI schemas.
 
 ```json
 {
@@ -123,6 +149,3 @@ The webhook must accept a `POST` request for an object in the following format:
     "schemas": { ...openapi schemas... }
 }
 ```
-
-And return the `schemas` object - that is, a dictionary of OpenAPI schemas.
-

--- a/docs/MOCK.md
+++ b/docs/MOCK.md
@@ -5,6 +5,7 @@ Meeshkan can be used to create a mock server from OpenAPI specifications and opt
 ## What's in this document
 
 - [The `meeshkan mock` command](#the-meeshkan-mock-command)
+    - [Making requests](#making-requests)
 - [Daemon mode](#daemon-mode)
 - [Callbacks](#callbacks)
     - [Function arguments](#function-arguments)
@@ -15,13 +16,19 @@ Meeshkan can be used to create a mock server from OpenAPI specifications and opt
 
 ## The `meeshkan mock` command
 
-To create a mock server from an OpenAPI spec, use the `meeshkan mock` command.
+To create your mock server, use the `meeshkan mock` command and include the path to the directory that your OpenAPI spec is in:
 
 ```bash
-$ meeshkan mock spec/dir/or/file
+$ meeshkan mock path/to/dir/
 ```
 
-_Note: The `--specs-dir` flag is telling Meeshkan to search for the OpenAPI spec inside the `specs` directory._
+Alternatively, you can also designate a path to one specific file:
+
+```bash
+$ meeshkan mock path/to/openapi.yml
+```
+
+### Making requests
 
 Keep this running. Then, in another terminal window, make a request using [curl](https://curl.haxx.se/):
 
@@ -29,7 +36,7 @@ Keep this running. Then, in another terminal window, make a request using [curl]
 $ curl http://localhost:8000/https://my.api.com/users
 ```
 
-Assuming that the directory `specs` contains an OpenAPI spec with the server `https://my.api.com`, this will return a mock of the resource `GET /users`.
+Assuming that your OpenAPI spec has the server `https://my.api.com`, this will return a mock of the resource `GET /users`.
 
 > More options for the `meeshkan mock` command an be seen by running `meeshkan mock --help`.
 

--- a/docs/RECORD.md
+++ b/docs/RECORD.md
@@ -37,7 +37,6 @@ To stop Meeshkan without losing your any of your data, type `Ctrl + C` or anothe
 By default, Meeshkan uses **path routing** to intercept HTTP API calls. Path routing is done by appending the URL you wish to call to the URL of the recording server.
 
 ```bash
-$ pip meeshkan # if not installed yet 
 $ meeshkan record
 ```
 

--- a/docs/RECORD.md
+++ b/docs/RECORD.md
@@ -6,6 +6,8 @@ Meeshkan can be used to record HTTP API traffic in a format that `meeshkan build
 
 - [The `meeshkan record` command](#the-meeshkan-record-command)
 - [Path vs. header routing](#path-vs-header-routing)
+    - [Path routing](#path-routing)
+    - [Header routing](#header-routing)
 - [Daemon mode](#daemon-mode)
 - [Ecosystem](#ecosystem)
     - [Client libraries](#client-libraries)
@@ -14,31 +16,40 @@ Meeshkan can be used to record HTTP API traffic in a format that `meeshkan build
 
 ## The `meeshkan record` command
 
-To start a Meeshkan server that will record HTTP API traffic, use the `meeshkan record` command.
+To start a Meeshkan server that will record HTTP API traffic, use the `meeshkan record` command:
 
-```sh
+```bash
 $ meeshkan record
 ```
+
 This starts Meeshkan as a reverse proxy on the default port of `8000`. Running `meeshkan record` will also generate two directories: `logs` and `specs`.
 
-By default, `meeshkan record` records all traffic to a folder called `logs`.  You can change the recording directory using the `--log_dir` flag, i.e. `--log_dir some_other_directory`. For a full list of recording options, type `meeshkan record --help`.
+By default, `meeshkan record` records all traffic to the `logs` directory.  You can change the recording directory using the `--log_dir` flag, i.e. `--log_dir path/to/directory`. 
+
+> More options for the `meeshkan record` command an be seen by running `meeshkan record --help`.
 
 To stop Meeshkan without losing your any of your data, type `Ctrl + C` or another `kill` command.  
 
 ## Path vs. header routing
 
-By default, Meeshkan uses **path routing** to intercept HTTP API calls.  Path routing is done by appending the URL you wish to call to the URL of the recording server.
+### Path routing
+
+By default, Meeshkan uses **path routing** to intercept HTTP API calls. Path routing is done by appending the URL you wish to call to the URL of the recording server.
 
 ```bash
+$ pip meeshkan # if not installed yet 
 $ meeshkan record
 ```
-Keep this running. Then, in another terminal window, type:
+
+Keep this running. Then, in another terminal window, you can use Meeshkan as a proxy with [curl](https://curl.haxx.se/):
 
 ```bash
 $ curl http://localhost:8000/http://time.jsontest.com
 ```
 
-Meeshkan will automatically make an API call using the URL in the path - in this case, [http://time.jsontest.com](http://time.jsontest.com), and return the response from the called API.
+Meeshkan will automatically make an API call using the URL in the path - in this case, [http://time.jsontest.com](http://time.jsontest.com) - and return the response from the called API.
+
+### Header routing
 
 Alternatively, you can run Meeshkan in **header** mode, which uses the host and optionally the schema reported in the header.
 
@@ -54,14 +65,17 @@ $ curl http://localhost:8000/api/v2/pokemon/ditto -H "Host: pokeapi.co" -H "X-Me
 This instructs meeshkan to call the [Pokemon API](pokeapi.co) and use the HTTPS protocol.
 
 ## Daemon mode
-Meeshkan can be launched as a daemon by providing the `--daemon` flag:
+
+Meeshkan can be launched as a [daemon](https://docs.docker.com/engine/reference/commandline/dockerd/) by providing the `--daemon` flag to the `meeshkan record` command:
+
 ```bash
 $ meeshkan record --daemon
 ```
 
-All other command line arguments remain the same.
+_Note: All other command line arguments remain the same._
 
-To stop the Meeshkan daemon, run:
+To stop your Meeshkan daemon, run:
+
 ```bash
 $ meeshkan record stop
 ```
@@ -74,7 +88,9 @@ Here are some other ways that you can create `.jsonl` files of server recordings
 
 ### Client libraries
 
-You can use one of the [`http-types`](https://github.com/meeshkan/http-types) client libraries to write recorded traffic as `.jsonl` files.  Here are the libraries that currently exist:
+You can use one of the [`http-types`](https://github.com/meeshkan/http-types) client libraries to write recorded traffic as `.jsonl` files. 
+
+Here are the libraries that currently exist:
 
 - [js-http-types](https://github.com/meeshkan/js-http-types) 
 - [java-http-types](https://github.com/meeshkan/java-http-types) 
@@ -82,7 +98,7 @@ You can use one of the [`http-types`](https://github.com/meeshkan/http-types) cl
 
 In the future, we hope to build client libraries in C#, C++, Go, Rust, Brainfuck, Haskell and OCaml.
 
-The following code snippet is an example of how you can use `py-http-types` to record HTTP traffic to `.jsonl` files directly in Python.
+The following code snippet is an example of how you can use `py-http-types` to record HTTP traffic to `.jsonl` files directly in Python:
 
 ```python
 import urllib.request as request
@@ -109,7 +125,7 @@ with open('recordings.jsonl', 'w') as recording_file:
 
 ### Integrations
 
-We plan on maintaining middleware and plugins for a variety of projects.  
+We plan on maintaining middleware and plugins for a variety of projects. 
 
 Here is a list of integrations that exist or are in development:
 
@@ -123,6 +139,6 @@ Here is a list of integrations that exist or are in development:
 
 ## Next up: Building with Meeshkan
 
-After you've recorded your API traffic with `meeshkan record`, you can use that data to to build an OpenAPI schema via the Meeshkan CLI. 
+After you've recorded your API traffic with `meeshkan record`, you can use that data to to build an OpenAPI specification via the Meeshkan CLI. 
 
 To learn how, visit our [building documentation](./docs/BUILD.md).

--- a/docs/RECORD.md
+++ b/docs/RECORD.md
@@ -1,6 +1,16 @@
 # Recording with Meeshkan
 
-Meeshkan can be used to record HTTP API traffic in a format that `meeshkan build` can understand.  This format serializes JSON objects in the [`http-types`](https://github.com/meeshkan/http-types) format written to a [`.jsonl`](https://jsonlines.org) file.
+Meeshkan can be used to record HTTP API traffic in a format that `meeshkan build` can understand.  This format serializes JSON objects in the [`http-types`](https://github.com/meeshkan/http-types) format written to a [`.jsonl`](https://jsonlines.org) file. By default, this file will be called `{hostname}-recordings.jsonl` with `{hostname}` referring to your API's host URL. 
+
+## What's in this document
+
+- [The `meeshkan record` command](#the-meeshkan-record-command)
+- [Path vs. header routing](#path-vs-header-routing)
+- [Daemon mode](#daemon-mode)
+- [Ecosystem](#ecosystem)
+    - [Client libraries](#client-libraries)
+    - [Integrations](#integrations)
+- [Next up: Building with Meeshkan](#next-up-building-with-meeshkan)
 
 ## The `meeshkan record` command
 
@@ -9,9 +19,11 @@ To start a Meeshkan server that will record HTTP API traffic, use the `meeshkan 
 ```sh
 $ meeshkan record
 ```
-This starts Meeshkan as a reverse proxy on the default port of `8000`.
+This starts Meeshkan as a reverse proxy on the default port of `8000`. Running `meeshkan record` will also generate two directories: `logs` and `specs`.
 
-By default, `meeshkan record` records all traffic to a folder called `logs`.  You can change the recording directory using the `-l` flag, i.e. `-l some_other_directory`. For a full list of recording options, type `meeshkan record --help`.
+By default, `meeshkan record` records all traffic to a folder called `logs`.  You can change the recording directory using the `--log_dir` flag, i.e. `--log_dir some_other_directory`. For a full list of recording options, type `meeshkan record --help`.
+
+To stop Meeshkan without losing your any of your data, type `Ctrl + C` or another `kill` command.  
 
 ## Path vs. header routing
 
@@ -20,7 +32,7 @@ By default, Meeshkan uses **path routing** to intercept HTTP API calls.  Path ro
 ```bash
 $ meeshkan record
 ```
-And then, in another terminal window, type:
+Keep this running. Then, in another terminal window, type:
 
 ```bash
 $ curl http://localhost:8000/http://time.jsontest.com
@@ -31,9 +43,9 @@ Meeshkan will automatically make an API call using the URL in the path - in this
 Alternatively, you can run Meeshkan in **header** mode, which uses the host and optionally the schema reported in the header.
 
 ```bash
-$ meeshkan record -r
+$ meeshkan record --header_routing
 ```
-Then, in another terminal window, run:
+Keep this running. Then, in another terminal window, run:
 
 ```bash
 $ curl http://localhost:8000/api/v2/pokemon/ditto -H "Host: pokeapi.co" -H "X-Meeshkan-Scheme: https"
@@ -42,17 +54,18 @@ $ curl http://localhost:8000/api/v2/pokemon/ditto -H "Host: pokeapi.co" -H "X-Me
 This instructs meeshkan to call the [Pokemon API](pokeapi.co) and use the HTTPS protocol.
 
 ## Daemon mode
-Meeshkan can be launched as a daemon by providing -d command-line argument:
+Meeshkan can be launched as a daemon by providing the `--daemon` flag:
 ```bash
-$ meeshkan record -d
+$ meeshkan record --daemon
 ```
 
-All other command line arguments stay the same.
+All other command line arguments remain the same.
 
-To stop meeshkan daemon run:
+To stop the Meeshkan daemon, run:
 ```bash
 $ meeshkan record stop
 ```
+
 ## Ecosystem
 
 In addition to using Meeshkan to record, there is a growing ecosystem of projects that one can use to create `.jsonl` files in the [`http-types`](https://github.com/meeshkan/http-types).  
@@ -107,3 +120,9 @@ Here is a list of integrations that exist or are in development:
 | Kong plugin | Log requests and responses to the Kong API Gateway using a variety of transport layers, including the file system and Apache Kafka. | In development |
 | AWS API Gateway Plugin | Log requests and responses to the AWS API Gateway using a variety of transport layers, including the file system and Apache Kafka. | In development |
 | Apigee Plugin | Log requests and responses to the Apigee API Gateway using a variety of transport layers, including the file system and Apache Kafka. | In development |
+
+## Next up: Building with Meeshkan
+
+After you've recorded your API traffic with `meeshkan record`, you can use that data to to build an OpenAPI schema via the Meeshkan CLI. 
+
+To learn how, visit our [building documentation](./docs/BUILD.md).


### PR DESCRIPTION
References #106.

I know there are discussions around restructuring the documentation and how we present Meeshkan as a developer tool. But in the meantime, I thought it'd be useful to update our existing documentation based on the points of improvement @fornwall and I outlined last week.

This PR covers the following (ended up bigger than I had initially planned 🙈):
- Update docs to reflect recordings filename changes in #100 
- Update docs to default build output changes in #99 
- Better flag descriptions in BUILD.md (ie the differences between using `-o` and `-a`)
- Link to instructions for installing curl or any other tool we mention
- Explain what a daemon is (provided link)
- Links to the next section at the end of each docs page
- Always write out the long format of options (like `--admin-port` instead of `-a`)
- Spelling and grammar checks
- Better structure with each docs page (table of contents, note/tip styling, etc)
- Rewording sections for clarity