### PR TITLE
Start using isort

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,18 +180,14 @@ python setup.py test
 
 Configuration for `pytest` is found in [pytest.ini](https://github.com/Meeshkan/meeshkan/tree/master/pytest.ini).
 
-#### `black`
+#### Formatting
 
-Run format checks:
+Formatting is checked by the above mentioned `python setup.py test` command.
 
-```bash
-$ black --check .
-```
+To fix formatting:
 
-Fix formatting:
-
-```bash
-$ black .
+```sh
+$ python setup.py format
 ```
 
 #### `flake8`

--- a/meeshkan/__init__.py
+++ b/meeshkan/__init__.py
@@ -1,8 +1,8 @@
+from . import build
+from .build import *
 from .prepare import ignore_warnings
 
 ignore_warnings()
 
-from .build import *
-from . import build
 
 __all__ = [*build.__all__]

--- a/meeshkan/__main__.py
+++ b/meeshkan/__main__.py
@@ -1,24 +1,25 @@
-from .prepare import ignore_warnings
-
-ignore_warnings()
-
 from io import StringIO
-from http_types.utils import HttpExchangeWriter
-import click
 from typing import Sequence
 
-from meeshkan.build.update_mode import UpdateMode
-from .config import setup, DEFAULT_SPECS_DIR
-from .logger import get as getLogger
-from .build.builder import BASE_SCHEMA, build_schema_async
-from .convert.pcap import convert_pcap
-from .sinks import AbstractSink, FileSystemSink
-from .sources import AbstractSource, KafkaSource, FileSource
-from .sources.kafka import KafkaSourceConfig
+import click
+from http_types.utils import HttpExchangeWriter
 from openapi_typed_2 import OpenAPIObject, convert_to_openapi
 from yaml import safe_load
+
+from meeshkan.build.update_mode import UpdateMode
+
+from .build.builder import BASE_SCHEMA, build_schema_async
+from .config import DEFAULT_SPECS_DIR, setup
+from .convert.pcap import convert_pcap
+from .logger import get as getLogger
 from .meeshkan_types import *
-from .serve.commands import record, mock
+from .prepare import ignore_warnings
+from .serve.commands import mock, record
+from .sinks import AbstractSink, FileSystemSink
+from .sources import AbstractSource, FileSource, KafkaSource
+from .sources.kafka import KafkaSourceConfig
+
+ignore_warnings()
 
 
 LOGGER = getLogger(__name__)

--- a/meeshkan/config.py
+++ b/meeshkan/config.py
@@ -1,8 +1,9 @@
+import logging
 import os
 from pathlib import Path
-from typing import Dict, Any, List
+from typing import Any, Dict, List
+
 import yaml
-import logging
 
 DEFAULT_SPECS_DIR = "specs/"
 

--- a/meeshkan/convert/pcap.py
+++ b/meeshkan/convert/pcap.py
@@ -1,15 +1,17 @@
 """Code for converting pcap to HttpExchange JSON format."""
 
-from sys import argv
-from typing import List, Optional, Dict, Any, Iterator, Union
-from http_types.utils import RequestBuilder, ResponseBuilder
-from pathlib import Path
 import csv
 import json
-import shutil
-from http_types import Request, Response, HttpExchange
 import re
+import shutil
 import subprocess
+from pathlib import Path
+from sys import argv
+from typing import Any, Dict, Iterator, List, Optional, Union
+
+from http_types import HttpExchange, Request, Response
+from http_types.utils import RequestBuilder, ResponseBuilder
+
 from ..logger import get as getLogger
 
 LOGGER = getLogger(__name__)

--- a/meeshkan/logger.py
+++ b/meeshkan/logger.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 from typing import List
+
 from .config import setup
 
 # Do not expose anything by default (internal module)

--- a/meeshkan/meeshkan_types.py
+++ b/meeshkan/meeshkan_types.py
@@ -1,6 +1,8 @@
 import asyncio
-from typing import Callable, Awaitable, AsyncIterable, Tuple
+from typing import AsyncIterable, Awaitable, Callable, Tuple
+
 from http_types import HttpExchange
+
 from .build.result import BuildResult
 
 HttpExchangeStream = AsyncIterable[HttpExchange]

--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -1,15 +1,15 @@
 import logging
-from meeshkan.serve.mock.rest import rest_middleware_manager
-from meeshkan.serve.mock.storage import storage_manager
 
 from tornado.httpserver import HTTPServer
 from tornado.web import Application
 
 from meeshkan.serve.admin.views import (
-    StorageView,
     RestMiddlewaresView,
     RestMiddlewareView,
+    StorageView,
 )
+from meeshkan.serve.mock.rest import rest_middleware_manager
+from meeshkan.serve.mock.storage import storage_manager
 
 logger = logging.getLogger(__name__)
 

--- a/meeshkan/serve/admin/views.py
+++ b/meeshkan/serve/admin/views.py
@@ -1,10 +1,10 @@
+import json
 import logging
 
 from tornado.web import RequestHandler
 
-from ..mock.storage import StorageManager
 from ..mock.rest import RestMiddlewareManager
-import json
+from ..mock.storage import StorageManager
 
 logger = logging.getLogger(__name__)
 

--- a/meeshkan/serve/commands.py
+++ b/meeshkan/serve/commands.py
@@ -1,17 +1,19 @@
 import os
+from logging import getLogger
 from pathlib import Path
 
 import click
 
-IS_WINDOWS = os.name == "nt"
-
-from logging import getLogger
 from meeshkan.serve.mock.server import MockServer
-from .record.proxy import RecordProxyRunner
-from .utils.routing import PathRouting, HeaderRouting
+
 from ..build.update_mode import UpdateMode
 from ..config import DEFAULT_SPECS_DIR
 from .mock.specs import load_specs
+from .record.proxy import RecordProxyRunner
+from .utils.routing import HeaderRouting, PathRouting
+
+IS_WINDOWS = os.name == "nt"
+
 
 MOCK_PID = Path.home().joinpath(".meeshkan/mock.pid")
 RECORD_PID = Path.home().joinpath(".meeshkan/record.pid")

--- a/meeshkan/serve/mock/callbacks.py
+++ b/meeshkan/serve/mock/callbacks.py
@@ -3,8 +3,9 @@ import importlib.util
 import inspect
 import json
 import logging
-from dataclasses import asdict
 import os
+from dataclasses import asdict
+
 from http_types.utils import ResponseBuilder
 
 from .storage import storage_manager

--- a/meeshkan/serve/mock/faker.py
+++ b/meeshkan/serve/mock/faker.py
@@ -2,9 +2,10 @@
 #### FAKER
 ########################
 import random
-from typing import Any
-from faker import Faker
 from functools import reduce
+from typing import Any
+
+from faker import Faker
 
 fkr = Faker()
 __all__ = ["fake_it"]

--- a/meeshkan/serve/mock/matcher.py
+++ b/meeshkan/serve/mock/matcher.py
@@ -1,41 +1,43 @@
-from functools import reduce
-import lenses
-from lenses import lens
-import jsonschema
-from meeshkan.build.operation import operation_from_string
-from meeshkan.serve.mock.specs import OpenAPISpecification
-from dataclasses import replace
 import json
 import re
-from http_types import Request
+from dataclasses import replace
+from functools import reduce
 from typing import (
-    cast,
+    Any,
+    Callable,
     List,
+    Mapping,
+    Optional,
     Sequence,
     Tuple,
     TypeVar,
-    Callable,
-    Optional,
-    Mapping,
     Union,
-    Any,
-)
-from openapi_typed_2 import (
-    convert_from_openapi,
-    OpenAPIObject,
-    Responses,
-    MediaType,
-    Response,
-    RequestBody,
-    Header,
-    Operation,
-    Parameter,
-    Components,
-    Reference,
-    Schema,
-    PathItem,
+    cast,
 )
 from urllib.parse import urlparse
+
+import jsonschema
+import lenses
+from http_types import Request
+from lenses import lens
+from openapi_typed_2 import (
+    Components,
+    Header,
+    MediaType,
+    OpenAPIObject,
+    Operation,
+    Parameter,
+    PathItem,
+    Reference,
+    RequestBody,
+    Response,
+    Responses,
+    Schema,
+    convert_from_openapi,
+)
+
+from meeshkan.build.operation import operation_from_string
+from meeshkan.serve.mock.specs import OpenAPISpecification
 
 C = TypeVar("C")
 D = TypeVar("D")

--- a/meeshkan/serve/mock/response_matcher.py
+++ b/meeshkan/serve/mock/response_matcher.py
@@ -1,26 +1,25 @@
 import json
 import logging
-from meeshkan.serve.mock.rest import rest_middleware_manager
 import random
+from typing import Mapping, Sequence, Union, cast
+
 from faker import Faker
-from typing import cast, Mapping, Union, Sequence
-from openapi_typed_2 import (
-    convert_from_openapi,
-    Reference,
-)
+from http_types import Request, Response
+from openapi_typed_2 import Reference, convert_from_openapi
+
+from meeshkan.serve.mock.faker import fake_it
 from meeshkan.serve.mock.matcher import (
-    get_response_from_ref,
-    match_request_to_openapi,
     change_ref,
     change_refs,
+    get_response_from_ref,
+    match_request_to_openapi,
     ref_name,
 )
-from meeshkan.serve.mock.faker import fake_it
+from meeshkan.serve.mock.rest import rest_middleware_manager
 from meeshkan.serve.mock.specs import OpenAPISpecification
 
 fkr = Faker()
 
-from http_types import Request, Response
 
 logger = logging.getLogger(__name__)
 

--- a/meeshkan/serve/mock/rest.py
+++ b/meeshkan/serve/mock/rest.py
@@ -1,11 +1,12 @@
-import logging
-from openapi_typed_2 import convert_to_openapi, convert_from_openapi
-from http_types import Request, HttpExchange
-from http_types.utils import HttpExchangeWriter, ResponseBuilder
-from io import StringIO
-import requests
 import json
+import logging
+from io import StringIO
 from typing import Sequence
+
+import requests
+from http_types import HttpExchange, Request
+from http_types.utils import HttpExchangeWriter, ResponseBuilder
+from openapi_typed_2 import convert_from_openapi, convert_to_openapi
 
 from meeshkan.serve.mock.specs import OpenAPISpecification
 

--- a/meeshkan/serve/mock/server.py
+++ b/meeshkan/serve/mock/server.py
@@ -1,7 +1,5 @@
 import logging
-from typing import Optional
-
-from typing import Sequence
+from typing import Optional, Sequence
 
 from tornado.httpserver import HTTPServer
 from tornado.ioloop import IOLoop
@@ -9,10 +7,10 @@ from tornado.web import Application
 
 from meeshkan.serve.admin.runner import start_admin
 from meeshkan.serve.mock.callbacks import CallbackManager, callback_manager
-from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.response_matcher import ResponseMatcher
+from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.views import MockServerView
-from meeshkan.serve.utils.routing import Routing, PathRouting
+from meeshkan.serve.utils.routing import PathRouting, Routing
 
 logger = logging.getLogger(__name__)
 

--- a/meeshkan/serve/mock/specs.py
+++ b/meeshkan/serve/mock/specs.py
@@ -1,13 +1,11 @@
-import os
-import logging
-from openapi_typed_2 import (
-    convert_to_openapi,
-    OpenAPIObject,
-)
-from typing import Sequence
 import json
-import yaml
+import logging
+import os
 from dataclasses import dataclass
+from typing import Sequence
+
+import yaml
+from openapi_typed_2 import OpenAPIObject, convert_to_openapi
 
 
 @dataclass

--- a/meeshkan/serve/mock/views.py
+++ b/meeshkan/serve/mock/views.py
@@ -4,8 +4,8 @@ from urllib import parse
 from http_types import RequestBuilder
 from tornado.web import RequestHandler
 
-from .callbacks import CallbackManager
 from ..utils.routing import Routing
+from .callbacks import CallbackManager
 from .response_matcher import ResponseMatcher
 
 logger = logging.getLogger(__name__)

--- a/meeshkan/serve/record/channel.py
+++ b/meeshkan/serve/record/channel.py
@@ -11,8 +11,9 @@ from http_types.utils import RequestBuilder
 from tornado.iostream import IOStream, SSLIOStream, StreamClosedError
 
 from meeshkan.serve.utils.routing import Routing
-from .proxy_callback import ProxyCallback
+
 from ..utils.http_utils import response_from_bytes
+from .proxy_callback import ProxyCallback
 
 logger = logging.getLogger(__name__)
 

--- a/meeshkan/serve/record/proxy.py
+++ b/meeshkan/serve/record/proxy.py
@@ -6,6 +6,7 @@ from http_types import Request, Response
 from meeshkan.serve.admin.runner import start_admin
 from meeshkan.serve.utils.data_callback import RequestLoggingCallback
 from meeshkan.serve.utils.routing import HeaderRouting
+
 from .channel import Channel
 from .proxy_callback import ProxyCallback
 

--- a/meeshkan/serve/utils/data_callback.py
+++ b/meeshkan/serve/utils/data_callback.py
@@ -1,13 +1,13 @@
+import json
 import logging
 import os
 
-import json
 from http_types import (
-    Request,
-    Response,
     HttpExchange,
     HttpExchangeWriter,
+    Request,
     RequestBuilder,
+    Response,
     ResponseBuilder,
 )
 from openapi_typed_2 import convert_from_openapi, convert_to_openapi

--- a/meeshkan/sinks/abstract.py
+++ b/meeshkan/sinks/abstract.py
@@ -1,6 +1,7 @@
 import abc
+from typing import Awaitable, Union
+
 from meeshkan.build.result import BuildResult
-from typing import Union, Awaitable
 
 
 class AbstractSink(abc.ABC):

--- a/meeshkan/sinks/file.py
+++ b/meeshkan/sinks/file.py
@@ -1,5 +1,6 @@
 from meeshkan.build.result import BuildResult
 from meeshkan.build.writer import write_build_result
+
 from .abstract import AbstractSink
 
 

--- a/meeshkan/sources/__init__.py
+++ b/meeshkan/sources/__init__.py
@@ -1,3 +1,3 @@
-from .kafka import KafkaSource
 from .abstract import AbstractSource
 from .file import FileSource
+from .kafka import KafkaSource

--- a/meeshkan/sources/abstract.py
+++ b/meeshkan/sources/abstract.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
-from typing import Tuple, Optional
+from typing import Optional, Tuple
+
 from ..meeshkan_types import HttpExchangeStream
 
 

--- a/meeshkan/sources/file.py
+++ b/meeshkan/sources/file.py
@@ -1,8 +1,10 @@
-from typing import AsyncIterable, Tuple, TextIO
+import asyncio
+from typing import AsyncIterable, TextIO, Tuple
+
 from http_types.types import HttpExchange
 from http_types.utils import HttpExchangeReader
+
 from .abstract import AbstractSource
-import asyncio
 
 
 class FileSource(AbstractSource):

--- a/meeshkan/sources/kafka.py
+++ b/meeshkan/sources/kafka.py
@@ -6,8 +6,8 @@ import faust
 from http_types.types import HttpExchange
 from http_types.utils import HttpExchangeBuilder
 
-from .abstract import AbstractSource
 from ..meeshkan_types import HttpExchangeStream
+from .abstract import AbstractSource
 
 
 @dataclass(frozen=True)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import sys
 from shutil import rmtree
 
-from setuptools import setup, Command, find_packages, errors
+from setuptools import Command, errors, find_packages, setup
 
 # Package meta-data.
 NAME = "meeshkan"
@@ -46,6 +46,7 @@ BUNDLE_REQUIREMENTS = [dep for _, bundle_dep in BUNDLES.items() for dep in bundl
 DEV = BUNDLE_REQUIREMENTS + [
     "black==19.10b0",
     "flake8",
+    "isort",
     "mypy",
     "pyhamcrest",
     "pylint",
@@ -113,8 +114,10 @@ TEST_COMMAND = "pytest"
 
 LINT_COMMAND = "flake8 --exclude .git,.venv,__pycache__,build,dist"
 
-FORMAT_COMMAND = "black ."
-FORMAT_CHECK_COMMAND = "black --check ."
+BLACK_FORMAT_COMMAND = "black ."
+ISORT_FORMAT_COMMAND = "isort -y"
+BLACK_CHECK_COMMAND = "black --check ."
+ISORT_CHECK_COMMAND = "isort --check-only"
 
 
 def build():
@@ -133,8 +136,14 @@ def check_style():
     run_sys_command(LINT_COMMAND, "Checking style failed")
 
 
+def enforce_formatting():
+    run_sys_command(ISORT_FORMAT_COMMAND, "Formatting with isort failed")
+    run_sys_command(BLACK_FORMAT_COMMAND, "Formatting with black failed")
+
+
 def check_formatting():
-    run_sys_command(FORMAT_CHECK_COMMAND, "Checking formatting failed")
+    run_sys_command(ISORT_CHECK_COMMAND, "Checking with isort failed")
+    run_sys_command(BLACK_CHECK_COMMAND, "Checking with black failed")
 
 
 class BuildDistCommand(SetupCommand):
@@ -147,6 +156,15 @@ class BuildDistCommand(SetupCommand):
         self.rmdir_if_exists(os.path.join(here, "dist"))
         self.status("Building Source and Wheel (universal) distribution...")
         build()
+
+
+class FormatCommand(SetupCommand):
+    """Enforce formatting."""
+
+    description = "Enforce formatting."
+
+    def run(self):
+        enforce_formatting()
 
 
 class TypeCheckCommand(SetupCommand):
@@ -225,6 +243,7 @@ setup(
     entry_points={"console_scripts": ENTRY_POINTS},
     cmdclass={
         "dist": BuildDistCommand,
+        "format": FormatCommand,
         "typecheck": TypeCheckCommand,
         "upload": UploadCommand,
         "test": TestCommand,

--- a/tests/convert/test_pcap.py
+++ b/tests/convert/test_pcap.py
@@ -1,5 +1,6 @@
-from meeshkan.convert.pcap import convert_pcap
 from hamcrest import assert_that, has_length
+
+from meeshkan.convert.pcap import convert_pcap
 
 PCAP_SAMPLE = "tests/convert/recordings/recordings.pcap"
 

--- a/tests/serve/admin/test_rest_middleware.py
+++ b/tests/serve/admin/test_rest_middleware.py
@@ -1,10 +1,10 @@
+import json
+
+import pytest
 from tornado.httpclient import HTTPRequest
 
 from meeshkan.serve.admin import make_admin_app
 from meeshkan.serve.mock.rest import rest_middleware_manager
-
-import pytest
-import json
 
 
 @pytest.fixture

--- a/tests/serve/mock/end-to-end/opbank/test_opbank.py
+++ b/tests/serve/mock/end-to-end/opbank/test_opbank.py
@@ -1,7 +1,7 @@
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+import json
 
 import pytest
-import json
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 from meeshkan.serve.mock.server import make_mocking_app
 from meeshkan.serve.mock.specs import load_specs

--- a/tests/serve/mock/test_body_echoing.py
+++ b/tests/serve/mock/test_body_echoing.py
@@ -1,9 +1,9 @@
 import pytest
+from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 
 from meeshkan.serve.mock.server import make_mocking_app
-from meeshkan.serve.utils.routing import PathRouting
 from meeshkan.serve.mock.specs import load_specs
-from tornado.httpclient import AsyncHTTPClient, HTTPRequest
+from meeshkan.serve.utils.routing import PathRouting
 
 
 @pytest.fixture

--- a/tests/serve/mock/test_faker.py
+++ b/tests/serve/mock/test_faker.py
@@ -1,5 +1,5 @@
-from meeshkan.serve.mock.matcher import valid_schema
 from meeshkan.serve.mock.faker import fake_it
+from meeshkan.serve.mock.matcher import valid_schema
 
 
 def test_faker_1():

--- a/tests/serve/mock/test_matcher.py
+++ b/tests/serve/mock/test_matcher.py
@@ -1,9 +1,11 @@
+import json
+from typing import Sequence
+
+from http_types import RequestBuilder
+from openapi_typed_2 import OpenAPIObject, convert_to_openapi
+
 from meeshkan.serve.mock.matcher import match_request_to_openapi
 from meeshkan.serve.mock.specs import OpenAPISpecification
-from openapi_typed_2 import OpenAPIObject, convert_to_openapi
-from http_types import RequestBuilder
-from typing import Sequence
-import json
 
 store: Sequence[OpenAPISpecification] = [
     OpenAPISpecification(

--- a/tests/serve/mock/test_matcher_helper_functions.py
+++ b/tests/serve/mock/test_matcher_helper_functions.py
@@ -1,21 +1,23 @@
-from meeshkan.serve.mock.matcher import (
-    match_urls,
-    use_if_header,
-    ref_name,
-    get_path_item_with_method,
-    matches,
-)
+from dataclasses import replace
+
 from openapi_typed_2 import (
+    OpenAPIObject,
     PathItem,
     Reference,
-    OpenAPIObject,
-    convert_to_Parameter,
-    convert_to_PathItem,
     convert_to_Components,
     convert_to_openapi,
+    convert_to_Parameter,
+    convert_to_PathItem,
     convert_to_Schema,
 )
-from dataclasses import replace
+
+from meeshkan.serve.mock.matcher import (
+    get_path_item_with_method,
+    match_urls,
+    matches,
+    ref_name,
+    use_if_header,
+)
 
 
 def test_match_urls():

--- a/tests/serve/mock/test_mocking_server_gen_petstore.py
+++ b/tests/serve/mock/test_mocking_server_gen_petstore.py
@@ -1,7 +1,7 @@
-from tornado.httpclient import HTTPRequest
+import json
 
 import pytest
-import json
+from tornado.httpclient import HTTPRequest
 
 from meeshkan.serve.mock.server import make_mocking_app
 from meeshkan.serve.mock.specs import load_specs

--- a/tests/serve/mock/test_views.py
+++ b/tests/serve/mock/test_views.py
@@ -6,10 +6,10 @@ from http_types import HttpMethod, Protocol
 from http_types.utils import ResponseBuilder
 from tornado.httpclient import HTTPRequest
 
+from meeshkan.serve.mock.callbacks import callback_manager
+from meeshkan.serve.mock.response_matcher import ResponseMatcher
 from meeshkan.serve.mock.server import make_mocking_app_
 from meeshkan.serve.utils.routing import HeaderRouting
-from meeshkan.serve.mock.response_matcher import ResponseMatcher
-from meeshkan.serve.mock.callbacks import callback_manager
 
 response = ResponseBuilder.from_dict(
     dict(

--- a/tests/serve/record/test_proxy.py
+++ b/tests/serve/record/test_proxy.py
@@ -4,13 +4,14 @@ from unittest.mock import Mock
 
 import pytest
 from http_types import HttpMethod, Protocol
-from meeshkan.serve.record.proxy import RecordProxy
-from meeshkan.serve.mock.server import make_mocking_app
-from meeshkan.serve.mock.specs import load_specs
-from meeshkan.serve.utils.data_callback import DataCallback
-from meeshkan.serve.utils.routing import PathRouting, StaticRouting, HeaderRouting
 from tornado.httpclient import HTTPRequest
 from tornado.testing import bind_unused_port
+
+from meeshkan.serve.mock.server import make_mocking_app
+from meeshkan.serve.mock.specs import load_specs
+from meeshkan.serve.record.proxy import RecordProxy
+from meeshkan.serve.utils.data_callback import DataCallback
+from meeshkan.serve.utils.routing import HeaderRouting, PathRouting, StaticRouting
 
 
 @pytest.fixture

--- a/tests/serve/utils/test_data_callback.py
+++ b/tests/serve/utils/test_data_callback.py
@@ -1,10 +1,10 @@
+import json
 import os
 import shutil
-import pytest
-import json
 
-from http_types import RequestBuilder, ResponseBuilder, HttpExchangeReader
-from openapi_typed_2 import convert_to_openapi, convert_from_openapi
+import pytest
+from http_types import HttpExchangeReader, RequestBuilder, ResponseBuilder
+from openapi_typed_2 import convert_from_openapi, convert_to_openapi
 
 from meeshkan import UpdateMode
 from meeshkan.build.builder import BASE_SCHEMA

--- a/tests/serve/utils/test_routing.py
+++ b/tests/serve/utils/test_routing.py
@@ -1,4 +1,4 @@
-from meeshkan.serve.utils.routing import PathRouting, HeaderRouting
+from meeshkan.serve.utils.routing import HeaderRouting, PathRouting
 
 
 def test_path_routing():

--- a/tests/sources/test_kafka.py
+++ b/tests/sources/test_kafka.py
@@ -1,7 +1,9 @@
-from meeshkan.sources.kafka import KafkaSourceConfig, KafkaSource
 import pytest
-from ..util import read_recordings_as_dict
 from hamcrest import assert_that, has_length
+
+from meeshkan.sources.kafka import KafkaSource, KafkaSourceConfig
+
+from ..util import read_recordings_as_dict
 
 exchanges = read_recordings_as_dict()
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,16 +1,18 @@
-from meeshkan.build.builder import BASE_SCHEMA
-from meeshkan.__main__ import cli, _convert
-from meeshkan.config import DEFAULT_SPECS_DIR
-from click.testing import CliRunner
-from .util import read_recordings_as_strings
-from hamcrest import assert_that, has_key
+import json
+import os
 from pathlib import Path
 from typing import List
-import os
-from openapi_typed_2 import OpenAPIObject, convert_from_openapi
-import json
-import pkg_resources
 
+import pkg_resources
+from click.testing import CliRunner
+from hamcrest import assert_that, has_key
+from openapi_typed_2 import OpenAPIObject, convert_from_openapi
+
+from meeshkan.__main__ import _convert, cli
+from meeshkan.build.builder import BASE_SCHEMA
+from meeshkan.config import DEFAULT_SPECS_DIR
+
+from .util import read_recordings_as_strings
 
 requests = read_recordings_as_strings()
 

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Dict, List
+
 from http_types import HttpExchange, HttpExchangeBuilder
 
 SAMPLE_RECORDINGS_PATH = "resources/github.jsonl"


### PR DESCRIPTION
isort (https://github.com/timothycrosley/isort) is a nice tool in the same spirit as black to have consistent imports without having to spend any effort thinking about it.

> isort your imports, so you don't have to

The manual changes in this PR are in `README.md` and `setup.py` - all other changes are the result of running `python setup.py format`.