### PR TITLE
Avoid ugly emoji for admin endpoint

### DIFF
--- a/meeshkan/serve/admin/runner.py
+++ b/meeshkan/serve/admin/runner.py
@@ -40,4 +40,4 @@ def start_admin(port):
     app = make_admin_app()
     http_server = HTTPServer(app)
     http_server.listen(port)
-    logger.info("⚙ Admin   http://localhost:%s/admin", port)
+    logger.info("• Admin   http://localhost:%s/admin", port)


### PR DESCRIPTION
Replace ⚙, which looks ugly depending on the font, with the more discrete •