### PR TITLE
Rename TestSink to MockSink to avoid pytest warnings.

### DIFF
--- a/tests/serve/mock/test_mocking_server_gen_fails.py
+++ b/tests/serve/mock/test_mocking_server_gen_fails.py
@@ -10,7 +10,7 @@ from meeshkan.serve.mock.specs import load_specs
 from meeshkan.serve.utils.routing import HeaderRouting
 
 
-class TestSink(AbstractSink):
+class MockSink(AbstractSink):
     def __init__(self):
         self.interactions = []
 
@@ -20,7 +20,7 @@ class TestSink(AbstractSink):
 
 @pytest.fixture
 def test_sink():
-    return TestSink()
+    return MockSink()
 
 
 @pytest.fixture

--- a/tests/serve/mock/test_mocking_server_gen_petstore.py
+++ b/tests/serve/mock/test_mocking_server_gen_petstore.py
@@ -10,7 +10,7 @@ from meeshkan.serve.mock.specs import load_specs
 from meeshkan.serve.utils.routing import HeaderRouting
 
 
-class TestSink(AbstractSink):
+class MockSink(AbstractSink):
     def __init__(self):
         self.interactions = []
 
@@ -20,7 +20,7 @@ class TestSink(AbstractSink):
 
 @pytest.fixture
 def test_sink():
-    return TestSink()
+    return MockSink()
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes pytest warning:
```
PytestCollectionWarning: cannot collect test class 'TestSink' because it has a __init__ constructor (from: tests/serve/mock/test_mocking_server_gen_fails.py)
    class TestSink(AbstractSink):
```