### PR TITLE
Simplify and enhance mock specs handling

### DIFF
--- a/docs/MOCK.md
+++ b/docs/MOCK.md
@@ -7,7 +7,7 @@ Meeshkan can be used to create a mock server from OpenAPI specifications and opt
 To create a mock server from an OpenAPI spec, use the `meeshkan mock` command.
 
 ```bash
-$ meeshkan mock --specs-dir spec_dir/
+$ meeshkan mock spec/dir/or/file
 ```
 
 And then, in another terminal window, type:
@@ -30,7 +30,7 @@ All other command line arguments stay the same.
 
 To stop meeshkan daemon run:
 ```bash
-$ meeshkan mock stop
+$ meeshkan mock --kill
 ```
 
 ## Callbacks

--- a/meeshkan/serve/commands.py
+++ b/meeshkan/serve/commands.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from logging import getLogger
 from pathlib import Path
 
@@ -31,12 +32,6 @@ def add_options(options):
 
 _common_server_options = [
     click.option("-p", "--port", default="8000", help="Server port."),
-    click.option(
-        "-s",
-        "--specs-dir",
-        default=DEFAULT_SPECS_DIR,
-        help="Directory with OpenAPI specifications.",
-    ),
     click.option("-d", "--daemon", is_flag=True, help="Run meeshkan as a daemon."),
     click.option(
         "-r",
@@ -48,6 +43,12 @@ _common_server_options = [
 
 _record_options = _common_server_options + [
     click.option("-l", "--log-dir", default="./logs", help="API calls logs direcotry"),
+    click.option(
+        "-s",
+        "--specs-dir",
+        default=DEFAULT_SPECS_DIR,
+        help="Directory with OpenAPI specifications.",
+    ),
     click.option(
         "-m",
         "--mode",
@@ -66,6 +67,7 @@ _mock_options = _common_server_options + [
         type=click.Path(exists=True, file_okay=False, resolve_path=True),
         help="Directory with callback scripts to modify behavior.",
     ),
+    click.option("-k", "--kill", is_flag=True, help="Stop the mock daemon."),
     click.option(
         "-l",
         "--log-dir",
@@ -73,28 +75,40 @@ _mock_options = _common_server_options + [
         type=click.Path(exists=False, file_okay=False, resolve_path=True),
         help="Directory where server logs are written.",
     ),
+    click.option(
+        "-s", "--status", is_flag=True, help="Show the status of the mock daemon."
+    ),
 ]
 
 
-@click.group(invoke_without_command=True)
+@click.command()
 @add_options(_mock_options)
-@click.pass_context
+@click.argument("specifications", nargs=-1)
 def mock(
-    ctx, callback_dir, log_dir, admin_port, port, specs_dir, header_routing, daemon
+    callback_dir,
+    log_dir,
+    admin_port,
+    port,
+    header_routing,
+    daemon,
+    kill,
+    status,
+    specifications,
 ):
     """
     Run a mock server using OpenAPI specifications.
     """
-    if ctx.invoked_subcommand is None:
-        ctx.forward(start_mock)
+    if kill:
+        stop_mocking()
+        sys.exit(0)
+    elif status:
+        status_mocking()
+        sys.exit(0)
 
-
-@mock.command(name="start")  # type: ignore
-@add_options(_mock_options)
-def start_mock(
-    callback_dir, log_dir, admin_port, port, specs_dir, header_routing, daemon
-):
-    specs = load_specs(specs_dir)
+    try:
+        specs = load_specs(specifications)
+    except Exception as e:
+        raise click.ClickException(str(e))
 
     server = MockServer(
         callback_dir=callback_dir,
@@ -116,7 +130,6 @@ def start_mock(
         server.run()
 
 
-@mock.command(name="stop")  # type: ignore
 def stop_mocking():
     if not IS_WINDOWS:
         import daemonocle
@@ -125,7 +138,6 @@ def stop_mocking():
         daemon.stop()
 
 
-@mock.command(name="status")  # type: ignore
 def status_mocking():
     if not IS_WINDOWS:
         import daemonocle

--- a/meeshkan/serve/mock/specs.py
+++ b/meeshkan/serve/mock/specs.py
@@ -49,13 +49,16 @@ def load_specs(specs: Union[str, Sequence[str]]) -> Sequence[OpenAPISpecificatio
         if is_http or os.path.isfile(spec):
             specs_paths = [spec]
         elif os.path.isdir(spec):
-            specs_paths = [
-                os.path.join(spec, dir_entry)
-                for dir_entry in os.listdir(spec)
-                if dir_entry.endswith("yml")
-                or dir_entry.endswith("yaml")
-                or dir_entry.endswith("json")
-            ]
+            specs_paths = []
+            for dir_path, dirs, files in os.walk(spec):
+                for filename in files:
+                    if (
+                        filename.endswith("yml")
+                        or filename.endswith("yaml")
+                        or filename.endswith("json")
+                    ):
+                        full_path = os.path.join(dir_path, filename)
+                        specs_paths.append(full_path)
         else:
             raise Exception(f"OpenAPI specification {spec} not found")
 

--- a/tests/serve/mock/test_control_via_rest.py
+++ b/tests/serve/mock/test_control_via_rest.py
@@ -16,7 +16,7 @@ from meeshkan.serve.utils.routing import HeaderRouting
 def app():
     return make_mocking_app(
         "tests/serve/mock/callbacks",
-        load_specs("tests/serve/mock/shemas/petstore"),
+        load_specs("tests/serve/mock/schemas/petstore"),
         HeaderRouting(),
         Log(Scope()),
     )

--- a/tests/serve/mock/test_specs.py
+++ b/tests/serve/mock/test_specs.py
@@ -1,0 +1,39 @@
+from typing import Sequence
+
+import requests_mock
+
+from meeshkan.serve.mock.specs import OpenAPISpecification, load_specs
+
+spec_directory = "tests/serve/mock/schemas/petstore"
+spec_file_path = f"{spec_directory}/index.yaml"
+
+
+def assert_on_petstore_spec(
+    specs: Sequence[OpenAPISpecification], expected_source: str
+):
+    assert len(specs) == 1
+    spec = specs[0]
+    assert expected_source == spec.source
+    assert "Swagger Petstore" == spec.api.info.title
+
+
+def test_load_specs_from_dir():
+    loaded_specs = load_specs((spec_directory,))
+    assert_on_petstore_spec(loaded_specs, spec_file_path)
+
+
+def test_load_specs_from_file():
+    loaded_specs = load_specs((spec_file_path,))
+    assert_on_petstore_spec(loaded_specs, spec_file_path)
+
+
+def test_load_specs_from_http():
+    with open(spec_file_path, encoding="utf8") as f:
+        spec_text = f.read()
+
+    for protocol in ["http", "https"]:
+        spec_url = f"{protocol}://api.example.com/index.yaml"
+        with requests_mock.Mocker() as m:
+            m.get(spec_url, text=spec_text)
+            loaded_specs = load_specs(spec_url)
+            assert_on_petstore_spec(loaded_specs, spec_url)


### PR DESCRIPTION
Remove the `-s,--specs-dir` option, so instead of

    meeshkan mock --specs-dir path/to/dir/

one runs

    meeshkan mock path/to/dir/

Also enhance it, so it can accept files as well:

    meeshkan mock path/to/spec.yaml

and http(s) urls:

    meeshkan mock https://example.com/spec.yaml

and multiple arguments:

    meeshkan mock spec1 spec2 [...]
    meeshkan mock examples/*stripe*

To do this it removes the (start, stop, status) subcommands to the mock command, which also simplifies help output, and replaces stopping and status of daemon with flags to meeshkan mock.