### PR TITLE
Change console logging level from DEBUG to INFO

### DIFF
--- a/meeshkan/logging.yaml
+++ b/meeshkan/logging.yaml
@@ -10,7 +10,7 @@ handlers:
     console_handler:
         class: logging.StreamHandler
         formatter: simple
-        level: DEBUG
+        level: INFO
         stream: ext://sys.stdout
 
     debug_file_handler:


### PR DESCRIPTION
This changes the terminal output for a single http access from:

```
Request(method=<HttpMethod.GET: 'get'>, headers={'Host': 'petstore.swagger.i
o', 'User-Agent': 'curl/7.64.1', 'Accept': '*/*'}, query={}, host='petstore.
swagger.io', path='/v1/pets', pathname='/v1/pets', protocol=<Protocol.HTTP:
'http'>, bodyAsJson='', timestamp=None, body='')
400 GET /http://petstore.swagger.io/v1/pets (::1) 7.80ms
```

to only keep the second line:

```
400 GET /http://petstore.swagger.io/v1/pets (::1) 7.80ms
```