### PR TITLE
Fix daemon mode under python 3.8+ (fixes #165)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ REQUIRED = [
     # mock
     "tornado==5.1.1",
     "urllib3==1.25.6",
-    "daemonocle",
+    "meeshkan-daemonocle",
 ]
 
 BUNDLES = {}


### PR DESCRIPTION
There is a python 3.8+ compatibility issue with daemonocle:
https://github.com/jnrbsn/daemonocle/pull/24

Until that fix is applied upstream (or us switching to another daemon library) we're switching to [our fork of the daemonocle library](https://github.com/meeshkan/daemonocle) with the above linked fix applied.