### PR TITLE
Replace setuptools.errors with distutils.errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 import os
 import sys
+from distutils import errors
 from shutil import rmtree
 
-from setuptools import Command, errors, find_packages, setup
+from setuptools import Command, find_packages, setup
 
 # Package meta-data.
 NAME = "meeshkan"


### PR DESCRIPTION
Doing this makes us compatible with the

    python3 -m venv .venv

setup, without any extra step required to use virtualenv or upgrade setuptools.