### PR TITLE
Fix black configuration.

### DIFF
--- a/meeshkan/build/builder.py
+++ b/meeshkan/build/builder.py
@@ -3,30 +3,78 @@ from sys import path
 from .update_mode import UpdateMode
 from functools import reduce
 from dataclasses import replace
-from typing import Any, List, Sequence, Iterable, AsyncIterable, cast, Tuple, Optional, Union, TypeVar, Type, Mapping
+from typing import (
+    Any,
+    List,
+    Sequence,
+    Iterable,
+    AsyncIterable,
+    cast,
+    Tuple,
+    Optional,
+    Union,
+    TypeVar,
+    Type,
+    Mapping,
+)
 from urllib.parse import urlunsplit
 from collections import defaultdict
 import json
 
 from http_types import HttpExchange as HttpExchange
-from openapi_typed_2 import Info, Paths, MediaType, Header, OpenAPIObject, PathItem, Response, Operation, Parameter, Reference, Server, Responses
+from openapi_typed_2 import (
+    Info,
+    Paths,
+    MediaType,
+    Header,
+    OpenAPIObject,
+    PathItem,
+    Response,
+    Operation,
+    Parameter,
+    Reference,
+    Server,
+    Responses,
+)
 from typeguard import check_type  # type: ignore
 
 from .operation import operation_from_string, new_path_item_at_operation
 from ..logger import get as getLogger
-from .media_types import infer_media_type_from_nonempty, build_media_type, update_media_type, MediaTypeKey, update_text_schema
+from .media_types import (
+    infer_media_type_from_nonempty,
+    build_media_type,
+    update_media_type,
+    MediaTypeKey,
+    update_text_schema,
+)
 from .paths import find_matching_path, RequestPathParameters
 from .param import ParamBuilder
 from .servers import normalize_path_if_matches
 from .result import BuildResult
 
-_DEFAULT_PATH_ITEM = {'servers': None, 'parameters': None, 'get': None, 'put': None, 'post': None, 'delete': None, 'options': None, 'head': None, 'patch': None, 'trace': None, '_ref': None, '_x': None} 
+_DEFAULT_PATH_ITEM = {
+    "servers": None,
+    "parameters": None,
+    "get": None,
+    "put": None,
+    "post": None,
+    "delete": None,
+    "options": None,
+    "head": None,
+    "patch": None,
+    "trace": None,
+    "_ref": None,
+    "_x": None,
+}
 
 logger = getLogger(__name__)
 
-__all__ = ['build_schema_batch', 'build_schema_online', 'update_openapi']
+__all__ = ["build_schema_batch", "build_schema_online", "update_openapi"]
 
-def build_response_content(exchange: HttpExchange, mode: UpdateMode) -> Optional[Tuple[MediaTypeKey, MediaType]]:
+
+def build_response_content(
+    exchange: HttpExchange, mode: UpdateMode
+) -> Optional[Tuple[MediaTypeKey, MediaType]]:
     """Build response content schema from exchange.
 
     Arguments:
@@ -37,7 +85,7 @@ def build_response_content(exchange: HttpExchange, mode: UpdateMode) -> Optional
     """
     body = exchange.response.body
 
-    if body == '':
+    if body == "":
         return None
 
     media_type_key = infer_media_type_from_nonempty(body)
@@ -67,24 +115,24 @@ def build_response(request: HttpExchange, mode: UpdateMode) -> Response:
             headers={},
             links={},
             content=None,
-            _x=None
+            _x=None,
         )
 
     media_type_key, media_type = content_or_none
-    content = {
-        media_type_key: media_type
-    }
+    content = {media_type_key: media_type}
 
     return Response(
         description="Response description",
         headers={},
         content=content,
         links={},
-        _x=None
+        _x=None,
     )
 
 
-def update_response(response: Response, mode: UpdateMode, exchange: HttpExchange) -> Response:
+def update_response(
+    response: Response, mode: UpdateMode, exchange: HttpExchange
+) -> Response:
     """Update response object.
 
     Response reference: https://swagger.io/specification/#responseObject
@@ -99,7 +147,7 @@ def update_response(response: Response, mode: UpdateMode, exchange: HttpExchange
     # TODO Update headers and links
     response_body = exchange.response.body
 
-    if response_body == '':
+    if response_body == "":
         # No body, do not do anything
         # TODO How to mark empty body as a possible response if non-empty responses exist
         return response
@@ -111,14 +159,21 @@ def update_response(response: Response, mode: UpdateMode, exchange: HttpExchange
     ################
     response_headers = response.headers if response.headers is not None else {}
     # TODO: accommodate array headers (currently cuts them off)
-    useable_headers: Mapping[str, str] = { k: v for k,v in exchange.response.headers.items() if k not in ['content-type', 'content-length', 'Content-Type', 'Content-Length'] and isinstance(v, str)}
+    useable_headers: Mapping[str, str] = {
+        k: v
+        for k, v in exchange.response.headers.items()
+        if k not in ["content-type", "content-length", "Content-Type", "Content-Length"]
+        and isinstance(v, str)
+    }
     new_headers = {
-            **response_headers,
-            **{
+        **response_headers,
+        **{
             k: Header(
-                schema=update_text_schema(v, mode, schema=response.headers.get(k, None))) for k, v in useable_headers.items()
-            }
-        }
+                schema=update_text_schema(v, mode, schema=response.headers.get(k, None))
+            )
+            for k, v in useable_headers.items()
+        },
+    }
 
     #############
     ### CONTENT
@@ -128,13 +183,18 @@ def update_response(response: Response, mode: UpdateMode, exchange: HttpExchange
         # Need to update existing media type
         existing_media_type = response_content[media_type_key]
         media_type = update_media_type(
-            exchange=exchange, mode=mode, type_key=media_type_key, media_type=existing_media_type)
+            exchange=exchange,
+            mode=mode,
+            type_key=media_type_key,
+            media_type=existing_media_type,
+        )
     else:
         media_type = build_media_type(
-            exchange=exchange, mode=mode, type_key=media_type_key)
+            exchange=exchange, mode=mode, type_key=media_type_key
+        )
 
     new_content: Mapping[str, MediaType] = {media_type_key: media_type}
-    response_content = {**response_content, **new_content }
+    response_content = {**response_content, **new_content}
     return replace(response, headers=new_headers, content=response_content)
 
 
@@ -154,19 +214,22 @@ def build_operation(exchange: HttpExchange, mode: UpdateMode) -> Operation:
 
     request_query_params = exchange.request.query
     request_header_params = exchange.request.headers
-    schema_query_params = ParamBuilder('query').build(request_query_params, mode)
-    schema_header_params = ParamBuilder('header').build(request_header_params, mode)
+    schema_query_params = ParamBuilder("query").build(request_query_params, mode)
+    schema_header_params = ParamBuilder("header").build(request_header_params, mode)
 
     operation = Operation(
         summary="Operation summary",
         description="Operation description",
         operationId="id",
         responses={code: response},
-        parameters=[*schema_query_params, *schema_header_params])
+        parameters=[*schema_query_params, *schema_header_params],
+    )
     return operation
 
 
-def update_operation(operation: Operation, request: HttpExchange, mode: UpdateMode) -> Operation:
+def update_operation(
+    operation: Operation, request: HttpExchange, mode: UpdateMode
+) -> Operation:
     """Update OpenAPI operation object.
 
     Operation reference: https://swagger.io/specification/#operationObject
@@ -188,36 +251,61 @@ def update_operation(operation: Operation, request: HttpExchange, mode: UpdateMo
         if not isinstance(existing_response, Reference):
             response = update_response(existing_response, mode, request)
         else:
-            raise ValueError('Meeshkan is not smart enough to build responses from references yet. Coming soon!')
+            raise ValueError(
+                "Meeshkan is not smart enough to build responses from references yet. Coming soon!"
+            )
     else:
         response = build_response(request, mode)
 
     # TODO: this is not right, we need to grab the references at some point!
-    existing_parameters: Sequence[Parameter] = [x for x in operation.parameters if not isinstance(x, Reference)] if operation.parameters is not None else []
-    request_query_params: Mapping[str, Union[str, Sequence[str]]] = request.request.query
-    request_header_params: Mapping[str, Union[str, Sequence[str]]] = request.request.headers
-    _updated_parameters = [*ParamBuilder('query').update(request_query_params,
-            mode, existing_parameters),
-            # TODO: can we avoid the cast below? it is pretty hackish
-        *ParamBuilder('header').update(request_header_params,
-            mode, existing_parameters)]
+    existing_parameters: Sequence[Parameter] = [
+        x for x in operation.parameters if not isinstance(x, Reference)
+    ] if operation.parameters is not None else []
+    request_query_params: Mapping[
+        str, Union[str, Sequence[str]]
+    ] = request.request.query
+    request_header_params: Mapping[
+        str, Union[str, Sequence[str]]
+    ] = request.request.headers
+    _updated_parameters = [
+        *ParamBuilder("query").update(request_query_params, mode, existing_parameters),
+        # TODO: can we avoid the cast below? it is pretty hackish
+        *ParamBuilder("header").update(
+            request_header_params, mode, existing_parameters
+        ),
+    ]
     updated_parameters: List[Parameter] = []
     for i, param in enumerate(_updated_parameters):
-        if len([x for x in _updated_parameters[i+1:] if (x.name == param.name) and (x._in == param._in)]) == 0:
+        if (
+            len(
+                [
+                    x
+                    for x in _updated_parameters[i + 1 :]
+                    if (x.name == param.name) and (x._in == param._in)
+                ]
+            )
+            == 0
+        ):
             updated_parameters.append(param)
-    new_responses: Mapping[str, Response] = { response_code: response }
-    return replace(operation, responses={ **operation.responses, **new_responses }, parameters = updated_parameters)
+    new_responses: Mapping[str, Response] = {response_code: response}
+    return replace(
+        operation,
+        responses={**operation.responses, **new_responses},
+        parameters=updated_parameters,
+    )
 
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 def verify_not_ref(item: Union[Reference, Any], expected_type: Type[T]) -> T:
-    assert not '$ref' in item, "Did not expect a reference"
+    assert not "$ref" in item, "Did not expect a reference"
     return cast(T, item)
 
 
-def update_openapi(schema: OpenAPIObject, exchange: HttpExchange, mode: UpdateMode) -> OpenAPIObject:
+def update_openapi(
+    schema: OpenAPIObject, exchange: HttpExchange, mode: UpdateMode
+) -> OpenAPIObject:
     """Update OpenAPI schema with a new request-response pair.
     Does not mutate the input schema.
 
@@ -231,8 +319,7 @@ def update_openapi(schema: OpenAPIObject, exchange: HttpExchange, mode: UpdateMo
 
     serverz = [] if schema.servers is None else schema.servers
 
-    normalized_pathname_or_none = normalize_path_if_matches(
-        exchange.request, serverz)
+    normalized_pathname_or_none = normalize_path_if_matches(exchange.request, serverz)
     if normalized_pathname_or_none is None:
         normalized_pathname = request_path
     else:
@@ -240,48 +327,77 @@ def update_openapi(schema: OpenAPIObject, exchange: HttpExchange, mode: UpdateMo
 
     schema_paths = schema.paths
     operation_candidate = build_operation(exchange, mode)
-    path_match_result = find_matching_path(normalized_pathname, schema_paths, request_method, operation_candidate)
+    path_match_result = find_matching_path(
+        normalized_pathname, schema_paths, request_method, operation_candidate
+    )
 
     request_path_parameters = {}
     make_new_paths = True
     if path_match_result is not None:
         # Path item exists for request path
-        path_item, request_path_parameters, pathname_with_wildcard, pathname_to_be_replaced_with_wildcard = path_match_result.path, path_match_result.param_mapping, path_match_result.pathname_with_wildcard, path_match_result.pathname_to_be_replaced_with_wildcard
+        (
+            path_item,
+            request_path_parameters,
+            pathname_with_wildcard,
+            pathname_to_be_replaced_with_wildcard,
+        ) = (
+            path_match_result.path,
+            path_match_result.param_mapping,
+            path_match_result.pathname_with_wildcard,
+            path_match_result.pathname_to_be_replaced_with_wildcard,
+        )
         # Create a wildcard if the mode is not replay/mixed
-        if (pathname_to_be_replaced_with_wildcard is not None):
+        if pathname_to_be_replaced_with_wildcard is not None:
             if mode == UpdateMode.GEN:
                 # the algorithm has updated the pathname, need to mutate
                 # the schema paths to use the new and discard the old if the old exists
                 # in the schema. it would not exist if we have already put a wildcard
                 pointer_to_value = schema_paths[pathname_to_be_replaced_with_wildcard]
-                schema_paths = { k: v for k, v in [(pathname_with_wildcard, pointer_to_value), *schema_paths.items()] if k != pathname_to_be_replaced_with_wildcard }
-                parameters_to_assign_to_pathname_with_wildcard = [] if schema_paths[pathname_with_wildcard].parameters is None else schema_paths[pathname_with_wildcard].parameters
+                schema_paths = {
+                    k: v
+                    for k, v in [
+                        (pathname_with_wildcard, pointer_to_value),
+                        *schema_paths.items(),
+                    ]
+                    if k != pathname_to_be_replaced_with_wildcard
+                }
+                parameters_to_assign_to_pathname_with_wildcard = (
+                    []
+                    if schema_paths[pathname_with_wildcard].parameters is None
+                    else schema_paths[pathname_with_wildcard].parameters
+                )
                 for path_param in request_path_parameters.keys():
-                    params = [x for x in parameters_to_assign_to_pathname_with_wildcard if not isinstance(x, Reference)]
-                    if not (path_param in [x.name for x in params if x._in == 'path']):
-                        parameters_to_assign_to_pathname_with_wildcard = [Parameter(
-                            required=True,
-                            _in='path',
-                            name=path_param,
-                        ), *parameters_to_assign_to_pathname_with_wildcard]
+                    params = [
+                        x
+                        for x in parameters_to_assign_to_pathname_with_wildcard
+                        if not isinstance(x, Reference)
+                    ]
+                    if not (path_param in [x.name for x in params if x._in == "path"]):
+                        parameters_to_assign_to_pathname_with_wildcard = [
+                            Parameter(required=True, _in="path", name=path_param,),
+                            *parameters_to_assign_to_pathname_with_wildcard,
+                        ]
                 schema_paths = {
                     **schema_paths,
-                    pathname_with_wildcard: replace(schema_paths[pathname_with_wildcard], parameters=parameters_to_assign_to_pathname_with_wildcard)
+                    pathname_with_wildcard: replace(
+                        schema_paths[pathname_with_wildcard],
+                        parameters=parameters_to_assign_to_pathname_with_wildcard,
+                    ),
                 }
-                make_new_paths = False # because we've already done it above
+                make_new_paths = False  # because we've already done it above
             else:
                 # we are using recordings, so we shouldn't overwrite anything
                 # we only add if it is not there yet
                 if normalized_pathname not in schema_paths:
                     # TODO: merge with liens below?
-                    path_item = PathItem(summary="Path summary",
-                             description="Path description")
+                    path_item = PathItem(
+                        summary="Path summary", description="Path description"
+                    )
                     request_path_parameters = {}
     else:
-        path_item = PathItem(summary="Path summary",
-                             description="Path description")
+        path_item = PathItem(summary="Path summary", description="Path description")
         request_path_parameters = {}
-        new_paths: Paths = { normalized_pathname: path_item }
+        new_paths: Paths = {normalized_pathname: path_item}
     existing_operation = operation_from_string(path_item, request_method)
     if existing_operation is not None:
         # Operation exists
@@ -290,34 +406,59 @@ def update_openapi(schema: OpenAPIObject, exchange: HttpExchange, mode: UpdateMo
         operation = operation_candidate
 
     path_item = new_path_item_at_operation(path_item, request_method, operation)
-    new_paths = { path_match_result.pathname_with_wildcard if (mode == UpdateMode.GEN) and ((path_match_result is not None) and (path_match_result.pathname_with_wildcard is not None)) else normalized_pathname: path_item } if make_new_paths else {}
-    new_server = Server(url=urlunsplit(
-            [str(exchange.request.protocol.value), exchange.request.host, '', '', '']))
+    new_paths = (
+        {
+            path_match_result.pathname_with_wildcard
+            if (mode == UpdateMode.GEN)
+            and (
+                (path_match_result is not None)
+                and (path_match_result.pathname_with_wildcard is not None)
+            )
+            else normalized_pathname: path_item
+        }
+        if make_new_paths
+        else {}
+    )
+    new_server = Server(
+        url=urlunsplit(
+            [str(exchange.request.protocol.value), exchange.request.host, "", "", ""]
+        )
+    )
     return replace(
         schema,
-        paths={ **schema_paths, **new_paths },
-        servers=serverz if (new_server.url in [x.url for x in serverz]) else [*serverz, new_server]
+        paths={**schema_paths, **new_paths},
+        servers=serverz
+        if (new_server.url in [x.url for x in serverz])
+        else [*serverz, new_server],
     )
 
 
-BASE_SCHEMA = OpenAPIObject(openapi="3.0.0",
-                            info=Info(title="API title",
-                                      description="API description",
-                                      version="1.0",
-                                      termsOfService=None,
-                                      contact=None,
-                                      _license=None,
-                                      _x=None),
-                            paths={},
-                            externalDocs=None,
-                            servers=None,
-                            security=None,
-                            tags=None,
-                            components=None,
-                            _x=None)
+BASE_SCHEMA = OpenAPIObject(
+    openapi="3.0.0",
+    info=Info(
+        title="API title",
+        description="API description",
+        version="1.0",
+        termsOfService=None,
+        contact=None,
+        _license=None,
+        _x=None,
+    ),
+    paths={},
+    externalDocs=None,
+    servers=None,
+    security=None,
+    tags=None,
+    components=None,
+    _x=None,
+)
 
 
-async def build_schema_async(async_iter: AsyncIterable[HttpExchange],  mode: UpdateMode, starting_spec: OpenAPIObject) -> AsyncIterable[BuildResult]:
+async def build_schema_async(
+    async_iter: AsyncIterable[HttpExchange],
+    mode: UpdateMode,
+    starting_spec: OpenAPIObject,
+) -> AsyncIterable[BuildResult]:
     schema = starting_spec
     async for exchange in async_iter:
         try:
@@ -328,7 +469,11 @@ async def build_schema_async(async_iter: AsyncIterable[HttpExchange],  mode: Upd
             raise
 
 
-def build_schema_online(requests: Iterable[HttpExchange], mode: UpdateMode, base_schema: OpenAPIObject = BASE_SCHEMA) -> OpenAPIObject:
+def build_schema_online(
+    requests: Iterable[HttpExchange],
+    mode: UpdateMode,
+    base_schema: OpenAPIObject = BASE_SCHEMA,
+) -> OpenAPIObject:
     """Build OpenAPI schema by iterating request-response pairs.
 
     OpenAPI object reference: https://swagger.io/specification/#oasObject
@@ -342,13 +487,18 @@ def build_schema_online(requests: Iterable[HttpExchange], mode: UpdateMode, base
 
     # Iterate over all request-response pairs in the iterator, starting from
     # BASE_SCHEMA
-    schema = reduce(lambda schema, req: update_openapi(
-        schema, req, mode), requests, base_schema)
+    schema = reduce(
+        lambda schema, req: update_openapi(schema, req, mode), requests, base_schema
+    )
 
     return schema
 
 
-def build_schema_batch(requests: List[HttpExchange], mode: UpdateMode = UpdateMode.GEN, base_schema: OpenAPIObject = BASE_SCHEMA) -> OpenAPIObject:
+def build_schema_batch(
+    requests: List[HttpExchange],
+    mode: UpdateMode = UpdateMode.GEN,
+    base_schema: OpenAPIObject = BASE_SCHEMA,
+) -> OpenAPIObject:
     """Build OpenAPI schema from a list of request-response object.
 
     OpenAPI object reference: https://swagger.io/specification/#oasObject

--- a/meeshkan/build/json_schema.py
+++ b/meeshkan/build/json_schema.py
@@ -4,15 +4,17 @@ from genson import SchemaBuilder  # type: ignore
 from openapi_typed_2 import Schema, convert_from_openapi
 from typing import Optional
 
+
 def decouple_types(s):
-    if isinstance(s, dict) and 'type' in s and isinstance(s['type'], list):
-        return { 'anyOf': [{'type':x} for x in s['type']]}
+    if isinstance(s, dict) and "type" in s and isinstance(s["type"], list):
+        return {"anyOf": [{"type": x} for x in s["type"]]}
     elif isinstance(s, dict):
-        return { k: decouple_types(v) for k,v in s.items()}
+        return {k: decouple_types(v) for k, v in s.items()}
     elif isinstance(s, list):
         return [decouple_types(x) for x in s]
     else:
         return s
+
 
 def _to_openapi_compatible(schema):
     """OpenAPI does not strictly use JSON schema so convert to the OpenAPI subset.
@@ -26,35 +28,36 @@ def _to_openapi_compatible(schema):
         Modified schema
     """
     schema = copy.deepcopy(schema)
-    if '$schema' in schema:
-        del schema['$schema']
+    if "$schema" in schema:
+        del schema["$schema"]
     #############################
     ## genson creates array types
     ## when merging simple types
     schema = decouple_types(schema)
     return schema
 
+
 def to_const(obj):
-    if type(obj) == type(''):
-        return { 'type': 'string', 'enum': [obj] }
+    if type(obj) == type(""):
+        return {"type": "string", "enum": [obj]}
     if type(obj) == type(0):
-        return { 'type': 'integer', 'enum': [obj] }
+        return {"type": "integer", "enum": [obj]}
     if type(obj) == type(0.0):
-        return { 'type': 'number', 'enum': [obj] }
+        return {"type": "number", "enum": [obj]}
     if obj is None:
-        return { 'type': 'null' }
+        return {"type": "null"}
     if type(obj) == type(True):
-        return { 'type': 'boolean', 'enum': [obj] }
+        return {"type": "boolean", "enum": [obj]}
     if type(obj) == type([]):
-        return { 'type': 'array', 'items': [to_const(x) for x in obj] }
+        return {"type": "array", "items": [to_const(x) for x in obj]}
     return {
-        'type': 'object',
-        'properties': { k: to_const(v) for k, v in obj.items() },
-        'required': [x for x in obj.keys()]
+        "type": "object",
+        "properties": {k: to_const(v) for k, v in obj.items()},
+        "required": [x for x in obj.keys()],
     }
 
 
-def to_json_schema(obj, mode: UpdateMode, schema:Optional[Schema]=None):
+def to_json_schema(obj, mode: UpdateMode, schema: Optional[Schema] = None):
     """Create JSON schema based on an object.
 
     Arguments:
@@ -76,13 +79,12 @@ def to_json_schema(obj, mode: UpdateMode, schema:Optional[Schema]=None):
         out = builder.to_schema()
         return out
     elif schema is None:
-        return { 'oneOf': [to_const(obj)] }
+        return {"oneOf": [to_const(obj)]}
     else:
-        return { 'oneOf': [to_const(obj), schema]}
+        return {"oneOf": [to_const(obj), schema]}
 
 
-
-def to_openapi_json_schema(obj, mode: UpdateMode, schema:Optional[Schema]=None):
+def to_openapi_json_schema(obj, mode: UpdateMode, schema: Optional[Schema] = None):
     """Create OpenAPI-compatible JSON schema from object.
 
     https://swagger.io/docs/specification/data-models/keywords/

--- a/meeshkan/build/media_types.py
+++ b/meeshkan/build/media_types.py
@@ -1,4 +1,3 @@
-
 """Code for building and inferring media types (application/json, text/plain, etc.) from HTTP exchanges."""
 from .update_mode import UpdateMode
 from http_types import HttpExchange as HttpExchange
@@ -12,22 +11,40 @@ from .json_schema import to_openapi_json_schema
 
 logger = getLogger(__name__)
 
-MediaTypeKey = Literal['application/json', 'text/plain']
+MediaTypeKey = Literal["application/json", "text/plain"]
 
 MEDIA_TYPE_FOR_NON_JSON = "text/plain"
 
 
-def update_json_schema(json_body: Any, mode: UpdateMode, schema: Optional[Any] = None) -> Schema:
+def update_json_schema(
+    json_body: Any, mode: UpdateMode, schema: Optional[Any] = None
+) -> Schema:
     out = to_openapi_json_schema(json_body, mode, schema)
     return convert_to_Schema(out)
 
-def update_text_schema(text_body: str, mode: UpdateMode, schema: Optional[Any] = None) -> Schema:
+
+def update_text_schema(
+    text_body: str, mode: UpdateMode, schema: Optional[Any] = None
+) -> Schema:
     # TODO Better updates
     generic = Schema(_type="string")
     specific = Schema(_type="string", enum=[text_body])
     # TODO don't merge equal schemas
-    return generic if mode == UpdateMode.GEN else Schema(
-        oneOf=[specific, *([] if schema is None else [schema] if schema.oneOf is None else schema.oneOf)]
+    return (
+        generic
+        if mode == UpdateMode.GEN
+        else Schema(
+            oneOf=[
+                specific,
+                *(
+                    []
+                    if schema is None
+                    else [schema]
+                    if schema.oneOf is None
+                    else schema.oneOf
+                ),
+            ]
+        )
     )
 
 
@@ -44,7 +61,7 @@ def infer_media_type_from_nonempty(body: str) -> MediaTypeKey:
         MediaTypeKey -- Media type such as "application/json"
     """
 
-    if body == '':
+    if body == "":
         raise Exception("Cannot infer media type from empty body.")
 
     try:
@@ -55,14 +72,19 @@ def infer_media_type_from_nonempty(body: str) -> MediaTypeKey:
         return MEDIA_TYPE_FOR_NON_JSON
 
     if isinstance(as_json, dict) or isinstance(as_json, list):
-        return 'application/json'
+        return "application/json"
     elif isinstance(as_json, str):
-        return 'text/plain'
+        return "text/plain"
     else:
         raise Exception(f"Not sure what to do with body: {body}")
 
 
-def update_media_type(exchange: HttpExchange, mode: UpdateMode, type_key: MediaTypeKey, media_type: Optional[MediaType] = None) -> MediaType:
+def update_media_type(
+    exchange: HttpExchange,
+    mode: UpdateMode,
+    type_key: MediaTypeKey,
+    media_type: Optional[MediaType] = None,
+) -> MediaType:
     """Update media type.
 
     Arguments:
@@ -87,9 +109,15 @@ def update_media_type(exchange: HttpExchange, mode: UpdateMode, type_key: MediaT
         schema = update_text_schema(body, mode, schema=existing_schema)
     else:
         raise Exception("Unknown type key")
-    media_type = MediaType(example=None, examples=None, encoding=None, _x=None, schema=schema)
+    media_type = MediaType(
+        example=None, examples=None, encoding=None, _x=None, schema=schema
+    )
     return media_type
 
 
-def build_media_type(exchange: HttpExchange, mode: UpdateMode, type_key: MediaTypeKey) -> MediaType:
-    return update_media_type(exchange=exchange, mode=mode, type_key=type_key, media_type=None)
+def build_media_type(
+    exchange: HttpExchange, mode: UpdateMode, type_key: MediaTypeKey
+) -> MediaType:
+    return update_media_type(
+        exchange=exchange, mode=mode, type_key=type_key, media_type=None
+    )

--- a/meeshkan/build/operation.py
+++ b/meeshkan/build/operation.py
@@ -2,32 +2,34 @@ from openapi_typed_2 import PathItem, Operation, Optional
 from typing import Callable, Mapping
 from dataclasses import replace
 
+
 def operation_from_string(p: PathItem, s: str) -> Optional[Operation]:
     lexicon: Mapping[str, Optional[Operation]] = {
-            "get": p.get,
-            "post": p.post,
-            "put": p.put,
-            "delete": p.delete,
-            "options": p.options,
-            "head": p.head,
-            "patch": p.patch,
-            "trace": p.trace,
-        }
+        "get": p.get,
+        "post": p.post,
+        "put": p.put,
+        "delete": p.delete,
+        "options": p.options,
+        "head": p.head,
+        "patch": p.patch,
+        "trace": p.trace,
+    }
     if s not in lexicon:
         return None
     return lexicon[s]
 
+
 def new_path_item_at_operation(p: PathItem, s: str, o: Operation) -> PathItem:
     lexicon = {
-            "get": {'get': o},
-            "post": {'post': o},
-            "put": {'put': o},
-            "delete": {'delete': o},
-            "options": {'options': o},
-            "head": {'head': o},
-            "patch": {'patch': o},
-            "trace": {'trace': o}
-        }
+        "get": {"get": o},
+        "post": {"post": o},
+        "put": {"put": o},
+        "delete": {"delete": o},
+        "options": {"options": o},
+        "head": {"head": o},
+        "patch": {"patch": o},
+        "trace": {"trace": o},
+    }
     if s not in lexicon:
         return p
     return replace(p, **lexicon[s])

--- a/meeshkan/build/param.py
+++ b/meeshkan/build/param.py
@@ -3,7 +3,13 @@
 from functools import reduce
 from meeshkan.build.json_schema import to_const
 from meeshkan.build.update_mode import UpdateMode
-from openapi_typed_2 import convert_to_Schema, Parameter, Reference, Schema, convert_to_Schema
+from openapi_typed_2 import (
+    convert_to_Schema,
+    Parameter,
+    Reference,
+    Schema,
+    convert_to_Schema,
+)
 from typing import Sequence, Union, cast, Sequence, List, Mapping
 from genson import SchemaBuilder  # type: ignore
 from dataclasses import replace
@@ -14,19 +20,27 @@ SchemaParameters = Sequence[Parameter]
 # maybe make more robust?
 def unnest(d: Sequence[Union[Reference, Schema]]) -> Sequence[Union[Reference, Schema]]:
     return sum(
-        [[x] if isinstance(x, Reference) or (x.oneOf is None) else unnest(x.oneOf) for x in d], [])
-    
+        [
+            [x] if isinstance(x, Reference) or (x.oneOf is None) else unnest(x.oneOf)
+            for x in d
+        ],
+        [],
+    )
+
 
 # TODO: extended this for all paramaters, but need to verify that
 # there is not some subtle difference between query and header
 
+
 class ParamBuilder:
     def __init__(self, _in: str):
-        if _in not in ['header', 'query']:
-            raise ValueError('A parameter cannot have an `in` value of %s.' % _in)
+        if _in not in ["header", "query"]:
+            raise ValueError("A parameter cannot have an `in` value of %s." % _in)
         self._in = _in
 
-    def build(self, params: Mapping[str, Union[str, Sequence[str]]], mode: UpdateMode) -> SchemaParameters:
+    def build(
+        self, params: Mapping[str, Union[str, Sequence[str]]], mode: UpdateMode
+    ) -> SchemaParameters:
         """Build a list of parameters from request parameters.
 
         Arguments:
@@ -40,8 +54,13 @@ class ParamBuilder:
         # can change later if there is a compelling reason
         return self.update(params, mode, existing, set_new_as_required=False)
 
-
-    def build_param(self, name: str, value: Union[str, Sequence[str]], required: bool, mode: UpdateMode) -> Parameter:
+    def build_param(
+        self,
+        name: str,
+        value: Union[str, Sequence[str]],
+        required: bool,
+        mode: UpdateMode,
+    ) -> Parameter:
         """Build a new OpenAPI compatible parameter definition from parameter
         name and value.
 
@@ -59,12 +78,12 @@ class ParamBuilder:
         else:
             value = value
         out: Schema
-        if (mode == UpdateMode.GEN):
+        if mode == UpdateMode.GEN:
             schema_builder = SchemaBuilder()
             schema_builder.add_object(value)
             out = convert_to_Schema(schema_builder.to_schema())
         else:
-            out = Schema(oneOf= [convert_to_Schema(to_const(value))])
+            out = Schema(oneOf=[convert_to_Schema(to_const(value))])
         schema = out
         return Parameter(
             description=None,
@@ -80,9 +99,8 @@ class ParamBuilder:
             name=name,
             schema=schema,
             required=required,
-            _in=self._in
+            _in=self._in,
         )
-
 
     def _update_required(self, param: Parameter, required: bool) -> Parameter:
         if param.required == required:
@@ -102,56 +120,69 @@ class ParamBuilder:
             name=param.name,
             _in=param._in,
             schema=param.schema,
-            required=required
+            required=required,
         )
 
-
     # TODO Fix types once openapi types are covariant
-    def update(self, incoming_params: Mapping[str, Union[str, Sequence[str]]], mode: UpdateMode, existing: SchemaParameters, set_new_as_required=False) -> SchemaParameters:
+    def update(
+        self,
+        incoming_params: Mapping[str, Union[str, Sequence[str]]],
+        mode: UpdateMode,
+        existing: SchemaParameters,
+        set_new_as_required=False,
+    ) -> SchemaParameters:
         non_params: List[Parameter] = [
-            param for param in existing if param._in != self._in]
+            param for param in existing if param._in != self._in
+        ]
 
-        params: List[Parameter] = [
-            param for param in existing if param._in == self._in]
+        params: List[Parameter] = [param for param in existing if param._in == self._in]
 
-        schema_params_names = frozenset(
-            [param.name for param in params])
+        schema_params_names = frozenset([param.name for param in params])
 
         request_param_names = frozenset(incoming_params.keys())
 
         # Parameters in request but not in schema
-        new_param_names = request_param_names.difference(
-            schema_params_names)
+        new_param_names = request_param_names.difference(schema_params_names)
 
         # Parameters in schema but not in request
-        missing_param_names = schema_params_names.difference(
-            request_param_names)
+        missing_param_names = schema_params_names.difference(request_param_names)
 
         # Parameters in schema and in request
-        shared_param_names = request_param_names.intersection(
-            schema_params_names)
+        shared_param_names = request_param_names.intersection(schema_params_names)
 
-        new_params = [self.build_param(name=param_name,
-                                            value=value,
-                                            required=set_new_as_required,
-                                            mode=mode)
-                            for param_name in new_param_names
-                            for value in (incoming_params[param_name],)]
+        new_params = [
+            self.build_param(
+                name=param_name, value=value, required=set_new_as_required, mode=mode
+            )
+            for param_name in new_param_names
+            for value in (incoming_params[param_name],)
+        ]
 
         # TODO Update shared incoming_params parameter schema
         shared_params = [
-            param if (mode == UpdateMode.GEN) else replace(param,
-                schema=Schema(oneOf=unnest([*([param.schema] if param.schema is not None else []), convert_to_Schema(to_const(incoming_params[param.name]))]))
-             ) for param in params if param.name in shared_param_names]
+            param
+            if (mode == UpdateMode.GEN)
+            else replace(
+                param,
+                schema=Schema(
+                    oneOf=unnest(
+                        [
+                            *([param.schema] if param.schema is not None else []),
+                            convert_to_Schema(to_const(incoming_params[param.name])),
+                        ]
+                    )
+                ),
+            )
+            for param in params
+            if param.name in shared_param_names
+        ]
 
         missing_params = [
-            self._update_required(param, required=False) for param in params if param.name in missing_param_names]
+            self._update_required(param, required=False)
+            for param in params
+            if param.name in missing_param_names
+        ]
 
         # TODO: make sure cast is valid
-        updated_params = [
-            *new_params,
-            *shared_params,
-            *missing_params,
-            *non_params
-        ]
+        updated_params = [*new_params, *shared_params, *missing_params, *non_params]
         return cast(SchemaParameters, updated_params)

--- a/meeshkan/build/paths.py
+++ b/meeshkan/build/paths.py
@@ -18,7 +18,9 @@ PATH_PARAMETER_PATTERN = r"""\\{([\w-]+)\\}"""
 RequestPathParameters = Mapping[str, str]
 
 
-def _dumb_match_to_path(request_path: str, paths: Paths, request_method: str, operation_candidate: Operation) -> Tuple[str, Optional[str], Optional[Mapping[str, Any]]]:
+def _dumb_match_to_path(
+    request_path: str, paths: Paths, request_method: str, operation_candidate: Operation
+) -> Tuple[str, Optional[str], Optional[Mapping[str, Any]]]:
     """An overly-simplistic, highly-experimental, probably-broken
        function that answers the question "does this path exist in the spec already?"
        For example, if there is /v1/clients/jane and we get
@@ -33,7 +35,9 @@ def _dumb_match_to_path(request_path: str, paths: Paths, request_method: str, op
        machine learning... the future... ooohhh....
     """
 
-    def could_these_two_paths_possibly_represent_the_same_underlying_path(a: str, b: str) -> bool:
+    def could_these_two_paths_possibly_represent_the_same_underlying_path(
+        a: str, b: str
+    ) -> bool:
         """Asks the question "Could these two paths theoretically be the same?
         Uses some brutish heuristics to answer it.
 
@@ -46,8 +50,8 @@ def _dumb_match_to_path(request_path: str, paths: Paths, request_method: str, op
         """
         if a is b:
             return True
-        a_spl = [x for x in a.split("/") if x != '']
-        b_spl = [x for x in b.split("/") if x != '']
+        a_spl = [x for x in a.split("/") if x != ""]
+        b_spl = [x for x in b.split("/") if x != ""]
         # if the two lengths aren't equal, return false
         if len(a_spl) != len(b_spl):
             return False
@@ -73,21 +77,40 @@ def _dumb_match_to_path(request_path: str, paths: Paths, request_method: str, op
         Returns:
             str -- A combined path
         """
-        
-        path0_split = [x for x in path0.split('/') if x != '']
-        path1_split = [x for x in path1.split('/') if x != '']
+
+        path0_split = [x for x in path0.split("/") if x != ""]
+        path1_split = [x for x in path1.split("/") if x != ""]
         if len(path0_split) != len(path1_split):
             raise ValueError("Incorrect use of path combination function")
-        return '/' + '/'.join([a if a == b else a if a[0] == '{' else b if b[0] == '{' else '{%s}' % ''.join(random.choices(string.ascii_lowercase, k=8)) for a, b in zip(path0_split, path1_split)])
+        return "/" + "/".join(
+            [
+                a
+                if a == b
+                else a
+                if a[0] == "{"
+                else b
+                if b[0] == "{"
+                else "{%s}" % "".join(random.choices(string.ascii_lowercase, k=8))
+                for a, b in zip(path0_split, path1_split)
+            ]
+        )
 
-    theoretically_plausible_paths = [path for path in paths.keys() if could_these_two_paths_possibly_represent_the_same_underlying_path(path, request_path)]
+    theoretically_plausible_paths = [
+        path
+        for path in paths.keys()
+        if could_these_two_paths_possibly_represent_the_same_underlying_path(
+            path, request_path
+        )
+    ]
     for path in theoretically_plausible_paths:
         operation = operation_from_string(paths[path], request_method)
         # TODO: could the operaiton ever return None above?
         # theoretically it can, but coudl it ever practically?
         # the `is not None` check below is for the typechecker
         # but what would it mean in the algorithm if we got None?
-        potential_conflicts = set(operation.responses.keys() if operation is not None else []).intersection(set(operation_candidate.responses.keys()))
+        potential_conflicts = set(
+            operation.responses.keys() if operation is not None else []
+        ).intersection(set(operation_candidate.responses.keys()))
         new_path = combine_paths_into_single_path(path, request_path)
         if len(potential_conflicts) != 0:
             irreconcilably_different = False
@@ -96,16 +119,31 @@ def _dumb_match_to_path(request_path: str, paths: Paths, request_method: str, op
                 # enough to call them the same thing
                 # if not, we deem them as irreconcilably different and give up
                 incumbent_potential_conflict = operation.responses[potential_conflict]
-                candidate_potential_conflict = operation_candidate.responses[potential_conflict]
-                if isinstance(incumbent_potential_conflict, Response) and isinstance(candidate_potential_conflict, Response):
-                    if (len(candidate_potential_conflict.content.keys()) != 1) or (len(incumbent_potential_conflict.content.keys()) != 1) or ([x for x in incumbent_potential_conflict.content.keys()] != [x for x in candidate_potential_conflict.content.keys()]):
+                candidate_potential_conflict = operation_candidate.responses[
+                    potential_conflict
+                ]
+                if isinstance(incumbent_potential_conflict, Response) and isinstance(
+                    candidate_potential_conflict, Response
+                ):
+                    if (
+                        (len(candidate_potential_conflict.content.keys()) != 1)
+                        or (len(incumbent_potential_conflict.content.keys()) != 1)
+                        or (
+                            [x for x in incumbent_potential_conflict.content.keys()]
+                            != [x for x in candidate_potential_conflict.content.keys()]
+                        )
+                    ):
                         # give up
                         irreconcilably_different = True
                         break
-                    s0 = [x for x in incumbent_potential_conflict.content.values()][0].schema
-                    s1 = [x for x in candidate_potential_conflict.content.values()][0].schema
+                    s0 = [x for x in incumbent_potential_conflict.content.values()][
+                        0
+                    ].schema
+                    s1 = [x for x in candidate_potential_conflict.content.values()][
+                        0
+                    ].schema
                     if s0 is not None and s1 is not None:
-                        diff = make_schema_diff(s0 ,s1)
+                        diff = make_schema_diff(s0, s1)
                         # If there are more than five things that are different between the specs,
                         # we deem them as irreconcilably different.
                         # This is based on the Helsinki Standard of Irreconcilable Differences Between JSON Objects,
@@ -122,12 +160,16 @@ def _dumb_match_to_path(request_path: str, paths: Paths, request_method: str, op
         # conflicts can be resolved, so we merge
         matches = _match_to_path(request_path, new_path)
         if matches is None:
-            raise ValueError('Algorithm conflict for path matching - got a match for %s %s, but then returned match === None' % (request_path, new_path))
+            raise ValueError(
+                "Algorithm conflict for path matching - got a match for %s %s, but then returned match === None"
+                % (request_path, new_path)
+            )
         # TODO: what if there is more than 1 theoretically plausible path?
         # in practice unlikely but possible if, for example, the spec has two conflicting
         # paths already in it
         return (new_path, path, matches)
     return (request_path, None, None)
+
 
 def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
     """Match a request path such as "/pets/32" to a variable path such as "/pets/{petId}".
@@ -141,7 +183,7 @@ def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
     """
     # this function won't work if
     # requests paths have a trailing slash, so we remove it
-    if request_path[-1] == '/':
+    if request_path[-1] == "/":
         request_path = request_path[:-1]
     path_as_regex, parameter_names = path_to_regex(path)
     match = path_as_regex.match(request_path)
@@ -152,18 +194,26 @@ def _match_to_path(request_path: str, path: str) -> Optional[Mapping[str, Any]]:
     captures = match.groups()
 
     assert len(parameter_names) == len(
-        captures), "Expected the number of parameter names in the path to match the number of captured parameter values"
+        captures
+    ), "Expected the number of parameter names in the path to match the number of captured parameter values"
 
-    return {parameter_name: parameter_value for parameter_name, parameter_value in zip(parameter_names, captures)}
+    return {
+        parameter_name: parameter_value
+        for parameter_name, parameter_value in zip(parameter_names, captures)
+    }
+
 
 @dataclass
 class MatchingPath:
-  path: PathItem
-  param_mapping: Mapping[str, Any]
-  pathname_with_wildcard: str
-  pathname_to_be_replaced_with_wildcard: Optional[str]
+    path: PathItem
+    param_mapping: Mapping[str, Any]
+    pathname_with_wildcard: str
+    pathname_to_be_replaced_with_wildcard: Optional[str]
 
-def find_matching_path(request_path: str, paths: Paths, request_method: str, operation_candidate: Operation) -> Optional[MatchingPath]:
+
+def find_matching_path(
+    request_path: str, paths: Paths, request_method: str, operation_candidate: Operation
+) -> Optional[MatchingPath]:
     """Find path that matches the request path.
 
     Arguments:
@@ -181,13 +231,24 @@ def find_matching_path(request_path: str, paths: Paths, request_method: str, ope
     # two paths are in fact similar.
     for fn in [
         lambda p, pi: (p, None, _match_to_path(request_path=request_path, path=p)),
-        lambda p, pi: _dumb_match_to_path(request_path, paths, request_method, operation_candidate)
-        ]:
+        lambda p, pi: _dumb_match_to_path(
+            request_path, paths, request_method, operation_candidate
+        ),
+    ]:
         for path, path_item in paths.items():
-            pathname_with_wildcard, pathname_to_be_replaced_with_wildcard, path_match = fn(path, path_item)
+            (
+                pathname_with_wildcard,
+                pathname_to_be_replaced_with_wildcard,
+                path_match,
+            ) = fn(path, path_item)
             if path_match is None:
                 continue
-            return MatchingPath(path=path_item, param_mapping=path_match, pathname_with_wildcard=pathname_with_wildcard, pathname_to_be_replaced_with_wildcard=pathname_to_be_replaced_with_wildcard)
+            return MatchingPath(
+                path=path_item,
+                param_mapping=path_match,
+                pathname_with_wildcard=pathname_with_wildcard,
+                pathname_to_be_replaced_with_wildcard=pathname_to_be_replaced_with_wildcard,
+            )
 
     return None
 
@@ -221,6 +282,6 @@ def path_to_regex(path: str) -> Tuple[Pattern[str], Tuple[str]]:
 
         escaped_path = escaped_path.replace(full_match, PATH_PARAMETER_REGEX)
 
-    regex_pattern = re.compile(r'^' + escaped_path + r'(?:\?|#|$)')
+    regex_pattern = re.compile(r"^" + escaped_path + r"(?:\?|#|$)")
 
     return (regex_pattern, tuple(param_names))

--- a/meeshkan/build/result.py
+++ b/meeshkan/build/result.py
@@ -1,5 +1,3 @@
-
-
 from typing_extensions import TypedDict
 from openapi_typed_2 import OpenAPIObject
 

--- a/meeshkan/build/schemadiff.py
+++ b/meeshkan/build/schemadiff.py
@@ -6,6 +6,7 @@ import enum
 ####################################
 #### does a diff on two schemas
 
+
 class SM(enum.Enum):
     SEQUENCE = 0
     MAPPING = 1
@@ -16,16 +17,32 @@ class SchemaDiff:
     differing_types: Sequence[Sequence[Union[str, SM]]] = field(default_factory=list)
     differing_keys: Sequence[Sequence[Union[str, SM]]] = field(default_factory=list)
 
-def make_schema_diff(s0: Union[Schema, Reference], s1: Union[Schema, Reference], path: Sequence[Union[str, SM]] = []) -> SchemaDiff:
+
+def make_schema_diff(
+    s0: Union[Schema, Reference],
+    s1: Union[Schema, Reference],
+    path: Sequence[Union[str, SM]] = [],
+) -> SchemaDiff:
     if isinstance(s0, Schema) and isinstance(s1, Schema):
         if s0._type != s1._type:
             return SchemaDiff(differing_types=[path])
-        elif s0._type == 'object':
-            props = [set(x.keys()) if x is not None else set([]) for x in [s0.properties, s1.properties]]
+        elif s0._type == "object":
+            props = [
+                set(x.keys()) if x is not None else set([])
+                for x in [s0.properties, s1.properties]
+            ]
             kdiff = props[0].symmetric_difference(props[1])
-            diffs = [make_schema_diff(s0.properties[p], s1.properties[p]) for p in props[0].intersection(props[1])]
-            return SchemaDiff(differing_types=sum([x.differing_types for x in diffs], []), differing_keys=sum([x.differing_keys for x in diffs], [[x, *path] for x in kdiff]))
-        elif s0._type == 'array':
+            diffs = [
+                make_schema_diff(s0.properties[p], s1.properties[p])
+                for p in props[0].intersection(props[1])
+            ]
+            return SchemaDiff(
+                differing_types=sum([x.differing_types for x in diffs], []),
+                differing_keys=sum(
+                    [x.differing_keys for x in diffs], [[x, *path] for x in kdiff]
+                ),
+            )
+        elif s0._type == "array":
             if type(s0.items) != type(s1.items):
                 return SchemaDiff(differing_types=[[SM.SEQUENCE, *path]])
             elif isinstance(s0.items, Schema) and isinstance(s1.items, Schema):

--- a/meeshkan/build/servers.py
+++ b/meeshkan/build/servers.py
@@ -4,7 +4,9 @@ from typing import List, Optional, Sequence
 from urllib.parse import urlparse
 
 
-def normalize_path_if_matches(request: Request, servers: Sequence[Server]) -> Optional[str]:
+def normalize_path_if_matches(
+    request: Request, servers: Sequence[Server]
+) -> Optional[str]:
     """Check if a request matches a list of mock definitions.
     If matches, return the request path normalized by the mock URL's basepath.
 
@@ -30,6 +32,6 @@ def normalize_path_if_matches(request: Request, servers: Sequence[Server]) -> Op
         if not request.pathname.startswith(server_url.path):
             continue
 
-        return request.pathname[len(server_url.path):]
+        return request.pathname[len(server_url.path) :]
 
     return None

--- a/meeshkan/build/update_mode.py
+++ b/meeshkan/build/update_mode.py
@@ -1,8 +1,10 @@
 import enum
 
+
 class UpdateMode(enum.Enum):
     GEN = 0
     REPLAY = 1
     MIXED = 2
 
-__all__ = ['UpdateMode']
+
+__all__ = ["UpdateMode"]

--- a/meeshkan/build/writer.py
+++ b/meeshkan/build/writer.py
@@ -10,7 +10,8 @@ from pathlib import Path
 LOGGER = getLogger(__name__)
 
 
-OPENAPI_FILENAME = 'openapi.json'
+OPENAPI_FILENAME = "openapi.json"
+
 
 def _ensure_dir_exists(path: Path) -> None:
     """Ensure directory at `path` exists. Does NOT create parent directories.
@@ -51,10 +52,10 @@ def write_build_result(directory: str, result: BuildResult) -> None:
 
     openapi_output = output_dir_path / OPENAPI_FILENAME
 
-    openapi_object = result['openapi']
+    openapi_object = result["openapi"]
 
     schema_json = cast(str, json.dumps(convert_from_openapi(openapi_object), indent=2))
 
-    with openapi_output.open('wb') as f:
+    with openapi_output.open("wb") as f:
         LOGGER.debug("Writing to: %s\n", str(openapi_output))
         f.write(schema_json.encode(encoding="utf-8"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+include = '[meeshkan|tests].*\.pyi?$'
+exclude = 'build\/lib'

--- a/tests/build/test_builder.py
+++ b/tests/build/test_builder.py
@@ -3,12 +3,24 @@ from meeshkan.build.update_mode import UpdateMode
 import json
 import re
 from dataclasses import replace
-from http_types import HttpExchange, Request, Response, RequestBuilder, HttpExchangeBuilder
+from http_types import (
+    HttpExchange,
+    Request,
+    Response,
+    RequestBuilder,
+    HttpExchangeBuilder,
+)
 from meeshkan.build import build_schema_batch, update_openapi, build_schema_online
 from meeshkan.build.builder import BASE_SCHEMA
 from meeshkan.build.update_mode import UpdateMode
 from ..util import read_recordings_as_request_response, POKEAPI_RECORDINGS_PATH
-from openapi_typed_2 import OpenAPIObject, Operation, PathItem, Schema, Response as _Response
+from openapi_typed_2 import (
+    OpenAPIObject,
+    Operation,
+    PathItem,
+    Schema,
+    Response as _Response,
+)
 from typeguard import check_type
 from yaml import safe_load
 from openapi_typed_2 import convert_to_openapi
@@ -18,16 +30,20 @@ from hamcrest import *
 requests = read_recordings_as_request_response()
 pokeapi_requests = read_recordings_as_request_response(POKEAPI_RECORDINGS_PATH)
 
-expected_schema = replace(BASE_SCHEMA, paths = {
-    '/user/repos': PathItem(
-        get=Operation(
-            responses={
-                '200': _Response(description="description"),
-                '403': _Response(description="description")
-            }
+expected_schema = replace(
+    BASE_SCHEMA,
+    paths={
+        "/user/repos": PathItem(
+            get=Operation(
+                responses={
+                    "200": _Response(description="description"),
+                    "403": _Response(description="description"),
+                }
+            )
         )
-    )
-})
+    },
+)
+
 
 @pytest.fixture
 def petstore_schema():
@@ -35,63 +51,77 @@ def petstore_schema():
         oas = convert_to_openapi(safe_load(f.read()))
         return oas
 
+
 @pytest.fixture
 def schema():
     return build_schema_batch(requests, UpdateMode.GEN)
 
 
 def test_schema_typechecks(schema):
-    check_type('schema', schema, OpenAPIObject)
+    check_type("schema", schema, OpenAPIObject)
+
 
 def test_schema_keys(schema):
     assert schema.openapi
     assert schema.info
     assert schema.paths
 
+
 def test_paths(schema):
     paths = schema.paths
-    assert '/user/repos' in paths
+    assert "/user/repos" in paths
+
 
 def test_get_operation(schema):
-    op = schema.paths['/user/repos'].get
+    op = schema.paths["/user/repos"].get
     assert op.responses
 
+
 def test_get_operation_responses(schema):
-    responses = schema.paths['/user/repos'].get.responses
-    assert '200' in responses
-    assert '403' in responses
+    responses = schema.paths["/user/repos"].get.responses
+    assert "200" in responses
+    assert "403" in responses
+
 
 def test_200_response(schema):
-    response = schema.paths['/user/repos'].get.responses['200']
-    assert 'x-dns-prefetch-control' in response.headers
+    response = schema.paths["/user/repos"].get.responses["200"]
+    assert "x-dns-prefetch-control" in response.headers
     assert response.links == {}
-    assert 'application/json' in response.content
-    media_type = response.content['application/json']
+    assert "application/json" in response.content
+    media_type = response.content["application/json"]
     assert media_type.schema
 
+
 def test_repos_content(schema):
-    content = schema.paths['/user/repos'].get.responses['200'].content
+    content = schema.paths["/user/repos"].get.responses["200"].content
     assert_that(content, has_key("application/json"))
-    json_content = content['application/json']
+    json_content = content["application/json"]
     assert json_content.schema
     schema = json_content.schema
     assert schema._type == "array"
     # TODO Typeguard for Reference
     assert isinstance(schema.items, Schema)
 
+
 def test_items(schema):
-    schema = schema.paths['/user/repos'].get.responses['200'].content['application/json'].schema
+    schema = (
+        schema.paths["/user/repos"]
+        .get.responses["200"]
+        .content["application/json"]
+        .schema
+    )
     items = schema.items
     assert isinstance(items, Schema)  # typeguard
     assert isinstance(items.properties, dict)
     properties = items.properties
-    assert_that(properties, has_entry('clone_url',
-                                        equal_to(Schema(_type= "string"))))
+    assert_that(properties, has_entry("clone_url", equal_to(Schema(_type="string"))))
+
 
 def test_servers(schema):
     servers = schema.servers
     assert 1 == len(servers)
-    assert 'http://api.github.com' == servers[0].url
+    assert "http://api.github.com" == servers[0].url
+
 
 def test_pokeapi_schema_valid(schema):
     # this should conflate to
@@ -105,12 +135,9 @@ def test_pokeapi_schema_valid(schema):
     paths = pokeapi_schema.paths.keys()
     assert_that(paths, has_length(4))
     assert_that(paths, has_item("/v2/pokemon/"))
-    assert_that(paths, has_item(
-        matches_regexp(r'\/v2\/pokemon\/\{[\w]+\}')))
-    assert_that(paths, has_item(
-        matches_regexp(r'\/v2\/type\/\{[\w]+\}')))
-    assert_that(paths, has_item(
-        matches_regexp(r'\/v2\/ability\/\{[\w]+\}')))
+    assert_that(paths, has_item(matches_regexp(r"\/v2\/pokemon\/\{[\w]+\}")))
+    assert_that(paths, has_item(matches_regexp(r"\/v2\/type\/\{[\w]+\}")))
+    assert_that(paths, has_item(matches_regexp(r"\/v2\/ability\/\{[\w]+\}")))
 
 
 def test_pokeapi_schema_valid_replay(schema):
@@ -118,42 +145,46 @@ def test_pokeapi_schema_valid_replay(schema):
     paths = list(pokeapi_schema.paths.keys())
     assert_that(paths, has_length(14))
     assert_that(paths, has_item("/v2/pokemon/"))
-    assert_that(paths, has_item(
-        matches_regexp(r'\/v2\/pokemon\/[\w]+\/')))
-    assert_that(paths, has_item(
-        matches_regexp(r'\/v2\/type\/[\w]+')))
-    assert_that(paths, has_item(
-        matches_regexp(r'\/v2\/ability\/[\w]+')))
+    assert_that(paths, has_item(matches_regexp(r"\/v2\/pokemon\/[\w]+\/")))
+    assert_that(paths, has_item(matches_regexp(r"\/v2\/type\/[\w]+")))
+    assert_that(paths, has_item(matches_regexp(r"\/v2\/ability\/[\w]+")))
 
 
-get_pets_req = RequestBuilder.from_url(
-    "http://petstore.swagger.io/v1/pets")
-get_one_pet_req = RequestBuilder.from_url(
-    "http://petstore.swagger.io/v1/pets/32")
+get_pets_req = RequestBuilder.from_url("http://petstore.swagger.io/v1/pets")
+get_one_pet_req = RequestBuilder.from_url("http://petstore.swagger.io/v1/pets/32")
 
 pet_res = Response(bodyAsJson=None, timestamp=None, body="", statusCode=200, headers={})
+
 
 @pytest.fixture
 def get_one_pet_exchange():
     return HttpExchange(request=get_one_pet_req, response=pet_res)
 
+
 @pytest.fixture
 def get_pets_exchange():
     return HttpExchange(request=get_pets_req, response=pet_res)
+
 
 @pytest.fixture
 def orig_schema_paths(petstore_schema):
     return list(petstore_schema.paths.keys())
 
-def test_update_respects_path_parameter(get_one_pet_exchange, orig_schema_paths, petstore_schema):
+
+def test_update_respects_path_parameter(
+    get_one_pet_exchange, orig_schema_paths, petstore_schema
+):
     updated_schema = update_openapi(
-        petstore_schema, get_one_pet_exchange, UpdateMode.GEN)
+        petstore_schema, get_one_pet_exchange, UpdateMode.GEN
+    )
     updated_schema_paths = list(updated_schema.paths.keys())
     assert_that(updated_schema_paths, is_(orig_schema_paths))
 
-def test_update_respects_basepath(get_pets_exchange, orig_schema_paths, petstore_schema):
-    updated_schema = update_openapi(
-        petstore_schema, get_pets_exchange, UpdateMode.GEN)
+
+def test_update_respects_basepath(
+    get_pets_exchange, orig_schema_paths, petstore_schema
+):
+    updated_schema = update_openapi(petstore_schema, get_pets_exchange, UpdateMode.GEN)
     updated_schema_paths = list(updated_schema.paths.keys())
     assert_that(updated_schema_paths, is_(orig_schema_paths))
 
@@ -162,30 +193,38 @@ def test_update_respects_basepath(get_pets_exchange, orig_schema_paths, petstore
 #### query params
 
 query_req = RequestBuilder.from_url(
-    url="https://petstore.swagger.io/v1/pets/32?id=1&car=ferrari")
-query_res = Response(body="", statusCode=200, headers={}, bodyAsJson=None, timestamp=None)
+    url="https://petstore.swagger.io/v1/pets/32?id=1&car=ferrari"
+)
+query_res = Response(
+    body="", statusCode=200, headers={}, bodyAsJson=None, timestamp=None
+)
+
 
 @pytest.fixture
 def query_exchange():
     return HttpExchange(request=query_req, response=query_res)
 
-req_wo_query = RequestBuilder.from_url(
-    url="https://petstore.swagger.io/v1/pets/32")
-res_wo_query = Response(body="", statusCode=200, headers={}, bodyAsJson=None, timestamp=None)
+
+req_wo_query = RequestBuilder.from_url(url="https://petstore.swagger.io/v1/pets/32")
+res_wo_query = Response(
+    body="", statusCode=200, headers={}, bodyAsJson=None, timestamp=None
+)
+
 
 @pytest.fixture
 def exchange_wo_query():
     return HttpExchange(request=req_wo_query, response=res_wo_query)
 
+
 @pytest.fixture
 def expected_path_name():
     return "/v1/pets/32"
 
+
 def test_build_with_query(query_exchange, expected_path_name):
     schema = build_schema_batch([query_exchange], UpdateMode.GEN)
 
-    assert_that(list(schema.paths.keys()),
-                is_([expected_path_name]))
+    assert_that(list(schema.paths.keys()), is_([expected_path_name]))
 
     operation = schema.paths[expected_path_name].get
 
@@ -197,9 +236,12 @@ def test_build_with_query(query_exchange, expected_path_name):
 
     parameter_names = [param.name for param in parameters]
 
-    assert_that(set(parameter_names), is_(set(['id', 'car'])))
+    assert_that(set(parameter_names), is_(set(["id", "car"])))
 
-def test_schema_update_with_query(exchange_wo_query, query_exchange, expected_path_name):
+
+def test_schema_update_with_query(
+    exchange_wo_query, query_exchange, expected_path_name
+):
     schema = build_schema_batch([exchange_wo_query], UpdateMode.GEN)
 
     operation = schema.paths[expected_path_name].get
@@ -216,15 +258,19 @@ def test_schema_update_with_query(exchange_wo_query, query_exchange, expected_pa
 
 
 text_request = RequestBuilder.from_url("https://example.com/v1")
-text_response = Response(statusCode=200, body="Hello World", headers={}, bodyAsJson=None, timestamp=None)
+text_response = Response(
+    statusCode=200, body="Hello World", headers={}, bodyAsJson=None, timestamp=None
+)
+
 
 @pytest.fixture
 def text_exchange():
     return HttpExchange(request=text_request, response=text_response)
 
+
 def test_build_string_body(text_exchange):
     schema = build_schema_batch([text_exchange], UpdateMode.GEN)
-    response_content = schema.paths['/v1'].get.responses['200'].content
+    response_content = schema.paths["/v1"].get.responses["200"].content
 
     assert_that(response_content, has_key("text/plain"))
 
@@ -235,23 +281,36 @@ def test_build_string_body(text_exchange):
 
 def test_schema_in_replay_mode():
     reqs = []
-    with open('tests/build/recordings/opbank/recordings.jsonl','r') as rr: 
-        reqs = rr.read().split('\n')
+    with open("tests/build/recordings/opbank/recordings.jsonl", "r") as rr:
+        reqs = rr.read().split("\n")
 
-    reqs = [HttpExchangeBuilder.from_dict(json.loads(r)) for r in reqs if r != '']
+    reqs = [HttpExchangeBuilder.from_dict(json.loads(r)) for r in reqs if r != ""]
     r = build_schema_batch(reqs, UpdateMode.REPLAY)
     # this schema has four recordings, of which two correspond to /v1/payments/confirm
-    assert 2 == len(r.paths['/v1/payments/confirm'].post.responses['201'].content['application/json'].schema.oneOf)
+    assert 2 == len(
+        r.paths["/v1/payments/confirm"]
+        .post.responses["201"]
+        .content["application/json"]
+        .schema.oneOf
+    )
+
 
 # TODO
 # this sullies the structure of the repo a bit as
 # we are reading from an odd loation
 # given where this test lives
 import time
-ACCEPTABLE_TIME = 10 # 10 seconds
+
+ACCEPTABLE_TIME = 10  # 10 seconds
+
+
 def test_builder_speed():
     now = time.time()
-    with open('tests/build/pokeapi/large.jsonl', 'r') as recordings:
-        http_exchanges = [HttpExchangeBuilder.from_dict(json.loads(d)) for d in recordings.read().split('\n') if d != '']
+    with open("tests/build/pokeapi/large.jsonl", "r") as recordings:
+        http_exchanges = [
+            HttpExchangeBuilder.from_dict(json.loads(d))
+            for d in recordings.read().split("\n")
+            if d != ""
+        ]
         build_schema_online(iter(http_exchanges), mode=UpdateMode.REPLAY)
     assert (time.time() - now) < ACCEPTABLE_TIME

--- a/tests/build/test_json_schema.py
+++ b/tests/build/test_json_schema.py
@@ -5,48 +5,42 @@ import json
 from hamcrest import *
 
 request_samples = read_recordings_as_dict()
-object_sample = json.loads(request_samples[0]['response']['body'])
+object_sample = json.loads(request_samples[0]["response"]["body"])
 
 
-test_objects = [
-    [
-        {'fork': True}
-    ],
-    [
-        {}
-    ]
-]
+test_objects = [[{"fork": True}], [{}]]
 
 
 def test_to_schema_from_array():
     schema = to_json_schema(object_sample, UpdateMode.GEN, schema=None)
     assert_that(schema, has_key("$schema"))
-    assert_that(schema, has_entry(
-        "$schema", starts_with('http://json-schema.org/schema#')))
+    assert_that(
+        schema, has_entry("$schema", starts_with("http://json-schema.org/schema#"))
+    )
     assert_that(schema, has_entry("type", "array"))
-    assert_that(schema, has_entry('items', instance_of(dict)))
+    assert_that(schema, has_entry("items", instance_of(dict)))
 
 
 def test_schema_with_array():
     schema = to_json_schema(test_objects[0], UpdateMode.GEN, schema=None)
     assert_that(schema, has_entry("items", instance_of(dict)))
-    items = schema['items']
+    items = schema["items"]
     assert isinstance(items, dict)  # typeguard
-    assert_that(items, has_entry('required', ['fork']))
-    assert_that(items, has_entry('properties', instance_of(dict)))
-    properties = items['properties']
+    assert_that(items, has_entry("required", ["fork"]))
+    assert_that(items, has_entry("properties", instance_of(dict)))
+    properties = items["properties"]
     assert_that(properties, has_entries(fork=instance_of(dict)))
-    forks = properties['fork']
+    forks = properties["fork"]
     assert_that(forks, has_entries(type="boolean"))
 
 
 def test_updating_schema_removes_required():
     schema = to_json_schema(test_objects[0], UpdateMode.GEN, schema=None)
     schema = to_json_schema(test_objects[1], UpdateMode.GEN, schema=schema)
-    items = schema['items']
+    items = schema["items"]
     assert isinstance(items, dict)  # typeguard
-    assert_that(items, has_entry('required', []))
-    assert_that(items, has_entry('properties', has_key("fork")))
+    assert_that(items, has_entry("required", []))
+    assert_that(items, has_entry("properties", has_key("fork")))
 
 
 def test_openapi_compatible_schema():

--- a/tests/build/test_paths.py
+++ b/tests/build/test_paths.py
@@ -4,6 +4,7 @@ from openapi_typed_2 import convert_to_Operation, convert_to_openapi
 import pytest
 from yaml import safe_load
 
+
 @pytest.fixture
 def schema():
     with open("tests/build/schemas/petstore/index.yaml", "r") as f:
@@ -12,7 +13,7 @@ def schema():
 
 
 def test_path_to_regex():
-    as_regex, parameters = path_to_regex('/pets/{id}')
+    as_regex, parameters = path_to_regex("/pets/{id}")
 
     # assert_that(as_regex.pattern, is_('^\\/pets\\/(\\w+)$'))
     # assert_that(as_regex.pattern, is_(r"""^\/pets\/(\w+)$"""))
@@ -25,12 +26,11 @@ def test_path_to_regex():
 
     assert_that("/pets/32/", not_(matches_regexp(as_regex)))
 
-    assert parameters == ('id', )
+    assert parameters == ("id",)
 
 
 def test_path_to_regex_with_multiple_params():
-    as_regex, _ = path_to_regex(
-        '/pets/{id}/items/{name}')
+    as_regex, _ = path_to_regex("/pets/{id}/items/{name}")
 
     assert_that("/pets/32/items/car", matches_regexp(as_regex))
 
@@ -39,28 +39,29 @@ def test_match_paths(schema):
     paths = schema.paths
     request_path = "/pets/32"
 
-    match_result = find_matching_path(request_path, paths, "get", convert_to_Operation({
-        'responses': {}
-    }))
+    match_result = find_matching_path(
+        request_path, paths, "get", convert_to_Operation({"responses": {}})
+    )
 
     assert match_result is not None
 
-    expected_path_item = schema.paths['/pets/{petId}']
+    expected_path_item = schema.paths["/pets/{petId}"]
     path_item, parameters = match_result.path, match_result.param_mapping
 
     assert_that(path_item, equal_to(expected_path_item))
-    assert_that(parameters, has_entry('petId', '32'))
+    assert_that(parameters, has_entry("petId", "32"))
+
 
 def test_match_paths_reference():
     request_path = "/pets/32#reference"
-    path = '/pets/{petId}#{ref}'
+    path = "/pets/{petId}#{ref}"
 
     parameters = _match_to_path(request_path, path)
 
-    assert_that(parameters, has_entry('petId', '32'))
-    assert_that(parameters, has_entry('ref', 'reference'))
+    assert_that(parameters, has_entry("petId", "32"))
+    assert_that(parameters, has_entry("ref", "reference"))
 
-    path = '/pets/{petId}'
+    path = "/pets/{petId}"
 
     parameters = _match_to_path(request_path, path)
-    assert_that(parameters, has_entry('petId', '32'))
+    assert_that(parameters, has_entry("petId", "32"))

--- a/tests/build/test_query.py
+++ b/tests/build/test_query.py
@@ -5,36 +5,37 @@ from openapi_typed_2 import Parameter, Schema
 from typing import cast
 from hamcrest import *
 
-req = RequestBuilder.from_url(
-    "https://petstore.swagger.io/v1/pets?id=32&car=ferrari")
+req = RequestBuilder.from_url("https://petstore.swagger.io/v1/pets?id=32&car=ferrari")
 
 
 def test_build_new_query():
     query = req.query
-    schema_query = ParamBuilder('query').build(query, UpdateMode.GEN)
+    schema_query = ParamBuilder("query").build(query, UpdateMode.GEN)
     assert_that(schema_query, has_length(2))
 
     query_parameter = get_query_parameter("id", schema_query)
 
-    assert query_parameter.name == 'id'
-    assert query_parameter._in == 'query'
-    assert query_parameter.schema._type == 'string'
+    assert query_parameter.name == "id"
+    assert query_parameter._in == "query"
+    assert query_parameter.schema._type == "string"
 
 
-required_query_parameter = Parameter(description=None,
-                                     deprecated=None,
-                                     allowEmptyValue=None,
-                                     style=None,
-                                     explode=None,
-                                     allowReserved=None,
-                                     content=None,
-                                     example=None,
-                                     examples=None,
-                                     _x=None,
-                                     name='key',
-                                     required=True,
-                                     schema=Schema(_type='string'),
-                                     _in='query')
+required_query_parameter = Parameter(
+    description=None,
+    deprecated=None,
+    allowEmptyValue=None,
+    style=None,
+    explode=None,
+    allowReserved=None,
+    content=None,
+    example=None,
+    examples=None,
+    _x=None,
+    name="key",
+    required=True,
+    schema=Schema(_type="string"),
+    _in="query",
+)
 
 
 def get_query_parameter(name: str, parameters: SchemaParameters) -> Parameter:
@@ -44,7 +45,9 @@ def get_query_parameter(name: str, parameters: SchemaParameters) -> Parameter:
 
 def test_update_query_should_update_required():
     query = req.query
-    updated_query = ParamBuilder('query').update(query, UpdateMode.GEN, [required_query_parameter])
+    updated_query = ParamBuilder("query").update(
+        query, UpdateMode.GEN, [required_query_parameter]
+    )
     assert_that(updated_query, has_length(3))
 
     updated_for_key = get_query_parameter("key", updated_query)

--- a/tests/build/test_servers.py
+++ b/tests/build/test_servers.py
@@ -6,10 +6,11 @@ from hamcrest import *
 from http_types import RequestBuilder
 
 
-petstore_req = RequestBuilder.from_url(
-    "https://petstore.swagger.io/v1/pets")
+petstore_req = RequestBuilder.from_url("https://petstore.swagger.io/v1/pets")
 
-petstore_server = Server(description=None, variables=None, _x=None, url="https://petstore.swagger.io/v1")
+petstore_server = Server(
+    description=None, variables=None, _x=None, url="https://petstore.swagger.io/v1"
+)
 
 
 def test_normalize_path_for_match():
@@ -18,7 +19,6 @@ def test_normalize_path_for_match():
 
 
 def test_no_match():
-    req_no_match = RequestBuilder.from_url(
-        "https://petstore.swagger.io/v2/pets")
+    req_no_match = RequestBuilder.from_url("https://petstore.swagger.io/v2/pets")
     norm_pathname = normalize_path_if_matches(req_no_match, [petstore_server])
     assert_that(norm_pathname, is_(None))


### PR DESCRIPTION
Fixes a configuration bug where `meeshkan/build` folder was neglected by Black as it excludes "build" pattern by default. Only new addition here is the `pyproject.toml` and running `black .`.
Required for #179 

- [ ]  Excluding `build` is done by excluding `build/lib`, not sure if this is the cleanest way but I couldn't find another way.