### PR TITLE
Replace virtualenv with venv in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you run into any issues, please [reach out to our team on Gitter](https://git
 ### Getting started
 
 1. Clone this repository: `git clone https://github.com/meeshkan/meeshkan`
-1. Create a virtual environment: `virtualenv .venv && source .venv/bin/activate`
+1. Create a virtual environment: `python3 -m venv .venv && source .venv/bin/activate`
 1. Install dependencies: `pip install --upgrade -e '.[dev]'`
 
 ### Tests


### PR DESCRIPTION
Since python 3.3 venv comes preinstalled with python, and is the recommended tool to use: https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/#installing-virtualenv

> Installing virtualenv
> Note: If you are using Python 3.3 or newer, the venv module is the preferred way to create and manage virtual environments. venv is included in the Python standard library and requires no additional installation. If you are using venv, you may skip this section.
