### PR TITLE
Remove pipenv from circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,8 @@ jobs: # A basic unit of work in a run
             echo 'export PATH=$(yarn global bin):$PATH' >> $BASH_ENV
             source $BASH_ENV
             yarn global add pyright
-            python setup.py test
+            black --check .
+            pytest
       - run:
           name: Run integretion tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,10 +25,10 @@ jobs: # A basic unit of work in a run
       - run:
           name: Create virtual environment
           command: |
-            python3 -m venv venv
-            source .venv/bin/activate
+            python3 -m virtualenv venv
+            . venv/bin/activate
             pip install -e .[dev]
-            echo 'source .venv/bin/activate' >> $BASH_ENV
+            echo '. venv/bin/activate' >> $BASH_ENV
       - run:
           name: Install pyright and run all checks
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ jobs: # A basic unit of work in a run
     docker: # run the steps with Docker
       # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
       - image: circleci/python:3.6.4-stretch
-        environment: # environment variables for primary container
-          PIPENV_VENV_IN_PROJECT: "true"
     steps: # steps that comprise the `build` job
       - checkout # check out source code to working directory
       - run:
@@ -25,13 +23,12 @@ jobs: # A basic unit of work in a run
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt update && sudo apt install yarn
       - run:
-          name: Install pipenv
+          name: Create virtual environment
           command: |
-            sudo pip install pipenv
-            pipenv install -e .[dev]
-            pipenv update
-            echo 'export VENV_HOME_DIR=$(pipenv --venv)' >> $BASH_ENV
-            echo 'source $VENV_HOME_DIR/bin/activate' >> $BASH_ENV
+            python3 -m venv venv
+            source .venv/bin/activate
+            pip install -e .[dev]
+            echo 'source .venv/bin/activate' >> $BASH_ENV
       - run:
           name: Install pyright and run all checks
           command: |

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tests,tornado,typeguard,typing_extensions,urllib3,yaml
+known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tornado,typeguard,typing_extensions,urllib3,yaml

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,5 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+skip=venv
 known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tornado,typeguard,typing_extensions,urllib3,yaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
-include = '[meeshkan|tests].*\.pyi?$'
+include = '\/((meeshkan)|(tests))\/(?!venv\/).*\.pyi?$'
 exclude = 'build\/lib'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional, Sequence
 
 import pytest
-from tests.util import MockSink
 from tornado.web import Application
 
 from meeshkan.serve.mock.callbacks import callback_manager
@@ -13,6 +12,7 @@ from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.storage.mock_data_store import MockDataStore
 from meeshkan.serve.mock.views import MockServerView
 from meeshkan.serve.utils.routing import Routing
+from tests.util import MockSink
 
 
 @pytest.fixture()

--- a/tests/serve/admin/test_storage.py
+++ b/tests/serve/admin/test_storage.py
@@ -1,11 +1,11 @@
 import pytest
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec_dict
 from tornado.httpclient import HTTPClientError, HTTPRequest
 
 from meeshkan.serve.admin import make_admin_app
 from meeshkan.serve.mock.scope import Scope
 from meeshkan.serve.mock.specs import OpenAPISpecification
+from tests.util import spec_dict
 
 scope = Scope()
 

--- a/tests/serve/mock/faker/test_stateful_faker.py
+++ b/tests/serve/mock/faker/test_stateful_faker.py
@@ -1,10 +1,10 @@
 from http_types import RequestBuilder
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec, spec_dict
 
 from meeshkan.serve.mock.faker.stateful_faker import StatefulFaker
 from meeshkan.serve.mock.matcher import valid_schema
 from meeshkan.serve.mock.specs import OpenAPISpecification
+from tests.util import spec, spec_dict
 
 
 def test_fake_array(mock_data_store):

--- a/tests/serve/mock/faker/test_stateless_faker.py
+++ b/tests/serve/mock/faker/test_stateless_faker.py
@@ -1,9 +1,9 @@
 from http_types import RequestBuilder
-from tests.util import spec
 
 from meeshkan.serve.mock.faker.stateless_faker import StatelessFaker
 from meeshkan.serve.mock.matcher import valid_schema
 from meeshkan.serve.mock.specs import OpenAPISpecification
+from tests.util import spec
 
 
 def test_faker_1():

--- a/tests/serve/mock/storage/test_entity.py
+++ b/tests/serve/mock/storage/test_entity.py
@@ -1,8 +1,8 @@
 from http_types import RequestBuilder
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import add_item, spec_dict
 
 from meeshkan.serve.mock.storage.entity import Entity
+from tests.util import add_item, spec_dict
 
 
 def test_insert():

--- a/tests/serve/mock/storage/test_mock_data.py
+++ b/tests/serve/mock/storage/test_mock_data.py
@@ -1,8 +1,8 @@
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec_dict
 
 from meeshkan.serve.mock.storage.entity import Entity
 from meeshkan.serve.mock.storage.mock_data import MockData
+from tests.util import spec_dict
 
 
 def test_add():

--- a/tests/serve/mock/storage/test_mock_data_store.py
+++ b/tests/serve/mock/storage/test_mock_data_store.py
@@ -1,8 +1,8 @@
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec, spec_dict
 
 from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.storage.mock_data_store import MockDataStore
+from tests.util import spec, spec_dict
 
 
 def test_add_mock_no_data():


### PR DESCRIPTION
- Removes `pipenv` from CircleCI build
- Reverts to explicitly using `pytest` and `black .` in CircleCI: invoking those from `python setup.py test` has the side-effect that for some reason the configuration `pyproject.toml` isn't read so Black tries to format `venv` folder