### PR TITLE
Use pre-commit to check formatting.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tests,tornado,typeguard,typing_extensions,urllib3,yaml
+known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tornado,typeguard,typing_extensions,urllib3,yaml

--- a/meeshkan/build/builder.py
+++ b/meeshkan/build/builder.py
@@ -1,53 +1,52 @@
+from dataclasses import replace
 from functools import reduce
-
 from typing import (
     Any,
-    List,
-    Sequence,
-    Iterable,
     AsyncIterable,
-    cast,
-    Tuple,
-    Optional,
-    Union,
-    TypeVar,
-    Type,
+    Iterable,
+    List,
     Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
 )
 from urllib.parse import urlunsplit
 
-from dataclasses import replace
 from http_types import HttpExchange as HttpExchange
 from openapi_typed_2 import (
-    Info,
-    Paths,
-    MediaType,
     Header,
+    Info,
+    MediaType,
     OpenAPIObject,
-    PathItem,
-    Response,
     Operation,
     Parameter,
+    PathItem,
+    Paths,
     Reference,
-    Server,
-    Responses,
     RequestBody,
+    Response,
+    Responses,
+    Server,
 )
 
+from ..logger import get as getLogger
 from .media_types import (
-    infer_media_type_from_nonempty,
-    build_media_type,
-    update_media_type,
     MediaTypeKey,
+    build_media_type,
+    infer_media_type_from_nonempty,
+    update_media_type,
     update_text_schema,
 )
-from .operation import operation_from_string, new_path_item_at_operation
+from .operation import new_path_item_at_operation, operation_from_string
 from .param import ParamBuilder
 from .paths import find_matching_path
 from .result import BuildResult
 from .servers import normalize_path_if_matches
 from .update_mode import UpdateMode
-from ..logger import get as getLogger
 
 _DEFAULT_PATH_ITEM = {
     "servers": None,

--- a/meeshkan/build/media_types.py
+++ b/meeshkan/build/media_types.py
@@ -1,12 +1,13 @@
 """Code for building and inferring media types (application/json, text/plain, etc.) from HTTP exchanges."""
-from .update_mode import UpdateMode
-from ..logger import get as getLogger
-from typing import Any, Sequence, cast, Optional
-from openapi_typed_2 import MediaType, Schema, convert_to_Schema
 import json
-from typing_extensions import Literal
-from .json_schema import to_openapi_json_schema
+from typing import Any, Optional, Sequence, cast
 
+from openapi_typed_2 import MediaType, Schema, convert_to_Schema
+from typing_extensions import Literal
+
+from ..logger import get as getLogger
+from .json_schema import to_openapi_json_schema
+from .update_mode import UpdateMode
 
 logger = getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -122,11 +122,7 @@ TEST_COMMAND = "pytest"
 
 LINT_COMMAND = "flake8 --exclude .git,.venv,__pycache__,build,dist"
 
-BLACK_FORMAT_COMMAND = "black ."
-ISORT_FORMAT_COMMAND = "isort -y"
-
-BLACK_CHECK_COMMAND = "black --check ."
-ISORT_CHECK_COMMAND = "pipenv run isort --check-only"
+PRECOMMIT_COMMAND = "pre-commit run --all-files"
 
 
 def build():
@@ -145,14 +141,8 @@ def check_style():
     run_sys_command(LINT_COMMAND, "Checking style failed")
 
 
-def enforce_formatting():
-    run_sys_command(ISORT_FORMAT_COMMAND, "Formatting with isort failed")
-    run_sys_command(BLACK_FORMAT_COMMAND, "Formatting with black failed")
-
-
-def check_formatting():
-    run_sys_command(ISORT_CHECK_COMMAND, "Checking with isort failed")
-    run_sys_command(BLACK_CHECK_COMMAND, "Checking with black failed")
+def precommit():
+    run_sys_command(PRECOMMIT_COMMAND, "Checking pre-commit failed")
 
 
 class BuildDistCommand(SetupCommand):
@@ -173,7 +163,7 @@ class FormatCommand(SetupCommand):
     description = "Enforce formatting."
 
     def run(self):
-        enforce_formatting()
+        precommit()
 
 
 class TypeCheckCommand(SetupCommand):
@@ -192,7 +182,7 @@ class TestCommand(SetupCommand):
 
     def run(self):
         self.status("Checking formatting...")
-        check_formatting()
+        precommit()
 
         self.status("Checking style...")
         check_style()

--- a/tests/build/test_builder.py
+++ b/tests/build/test_builder.py
@@ -1,24 +1,21 @@
 import json
+import time
+from dataclasses import replace
 
 import pytest
-from dataclasses import replace
 from hamcrest import *
-from http_types import HttpExchange, Response, RequestBuilder, HttpExchangeBuilder
-from meeshkan.build import build_schema_batch, update_openapi, build_schema_online
-from meeshkan.build.builder import BASE_SCHEMA
-from meeshkan.build.update_mode import UpdateMode
-from openapi_typed_2 import (
-    OpenAPIObject,
-    Operation,
-    PathItem,
-    Schema,
-    Response as _Response,
-)
-from openapi_typed_2 import convert_to_openapi
+from http_types import HttpExchange, HttpExchangeBuilder, RequestBuilder, Response
+from openapi_typed_2 import OpenAPIObject, Operation, PathItem
+from openapi_typed_2 import Response as _Response
+from openapi_typed_2 import Schema, convert_to_openapi
 from typeguard import check_type
 from yaml import safe_load
 
-from ..util import read_recordings_as_request_response, POKEAPI_RECORDINGS_PATH
+from meeshkan.build import build_schema_batch, build_schema_online, update_openapi
+from meeshkan.build.builder import BASE_SCHEMA
+from meeshkan.build.update_mode import UpdateMode
+
+from ..util import POKEAPI_RECORDINGS_PATH, read_recordings_as_request_response
 
 requests = read_recordings_as_request_response()
 pokeapi_requests = read_recordings_as_request_response(POKEAPI_RECORDINGS_PATH)
@@ -287,12 +284,6 @@ def test_schema_in_replay_mode():
         .schema.oneOf
     )
 
-
-# TODO
-# this sullies the structure of the repo a bit as
-# we are reading from an odd loation
-# given where this test lives
-import time
 
 ACCEPTABLE_TIME = 10  # 10 seconds
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional, Sequence
 
 import pytest
-from tests.util import MockSink
 from tornado.web import Application
 
 from meeshkan.serve.mock.callbacks import callback_manager
@@ -13,6 +12,7 @@ from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.storage.mock_data_store import MockDataStore
 from meeshkan.serve.mock.views import MockServerView
 from meeshkan.serve.utils.routing import Routing
+from tests.util import MockSink
 
 
 @pytest.fixture()

--- a/tests/serve/admin/test_storage.py
+++ b/tests/serve/admin/test_storage.py
@@ -1,11 +1,11 @@
 import pytest
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec_dict
 from tornado.httpclient import HTTPClientError, HTTPRequest
 
 from meeshkan.serve.admin import make_admin_app
 from meeshkan.serve.mock.scope import Scope
 from meeshkan.serve.mock.specs import OpenAPISpecification
+from tests.util import spec_dict
 
 scope = Scope()
 

--- a/tests/serve/mock/faker/test_stateful_faker.py
+++ b/tests/serve/mock/faker/test_stateful_faker.py
@@ -1,10 +1,10 @@
 from http_types import RequestBuilder
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec, spec_dict
 
 from meeshkan.serve.mock.faker.stateful_faker import StatefulFaker
 from meeshkan.serve.mock.matcher import valid_schema
 from meeshkan.serve.mock.specs import OpenAPISpecification
+from tests.util import spec, spec_dict
 
 
 def test_fake_array(mock_data_store):

--- a/tests/serve/mock/faker/test_stateless_faker.py
+++ b/tests/serve/mock/faker/test_stateless_faker.py
@@ -1,9 +1,9 @@
 from http_types import RequestBuilder
-from tests.util import spec
 
 from meeshkan.serve.mock.faker.stateless_faker import StatelessFaker
 from meeshkan.serve.mock.matcher import valid_schema
 from meeshkan.serve.mock.specs import OpenAPISpecification
+from tests.util import spec
 
 
 def test_faker_1():

--- a/tests/serve/mock/storage/test_entity.py
+++ b/tests/serve/mock/storage/test_entity.py
@@ -1,8 +1,8 @@
 from http_types import RequestBuilder
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import add_item, spec_dict
 
 from meeshkan.serve.mock.storage.entity import Entity
+from tests.util import add_item, spec_dict
 
 
 def test_insert():

--- a/tests/serve/mock/storage/test_mock_data.py
+++ b/tests/serve/mock/storage/test_mock_data.py
@@ -1,8 +1,8 @@
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec_dict
 
 from meeshkan.serve.mock.storage.entity import Entity
 from meeshkan.serve.mock.storage.mock_data import MockData
+from tests.util import spec_dict
 
 
 def test_add():

--- a/tests/serve/mock/storage/test_mock_data_store.py
+++ b/tests/serve/mock/storage/test_mock_data_store.py
@@ -1,8 +1,8 @@
 from openapi_typed_2 import convert_to_OpenAPIObject
-from tests.util import spec, spec_dict
 
 from meeshkan.serve.mock.specs import OpenAPISpecification
 from meeshkan.serve.mock.storage.mock_data_store import MockDataStore
+from tests.util import spec, spec_dict
 
 
 def test_add_mock_no_data():


### PR DESCRIPTION
- Use `pre-commit run --all-files` in `python setup.py test` instead of manual Black and isort commands
- **`setup.py` is the only file changed by hand, so only reviewing that is necessary**
- Using `black` and `isort` in `python setup.py test` is problematic as those may conflict with `pre-commit` hooks (which also run black and isort). For example, formatting `meeshkan/build` is currently ignored by `black .` but is checked by `pre-commit run black --all-files`.
- Fix formatting in `meeshkan/build` and `tests/build`
- For some reason, `tests` was previously included in `known_third_party` but now the hook removed it (as it should).