### PR TITLE
Check formatting in separate CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,17 @@ workflows:
       - test-3.6
       - test-3.7
       - test-3.8
+
+prepare: &prepare
+  - checkout # check out source code to working directory
+  - run:
+    name: Create virtualenvironment
+    command: |
+      python -m venv venv
+      . venv/bin/activate
+      pip install -e .[dev]
+      echo '. venv/bin/activate' >> $BASH_ENV
+
 jobs: # A basic unit of work in a run
   test-3.6: &test-template # directory where steps are run
     working_directory: ~/meeshkan
@@ -15,7 +26,7 @@ jobs: # A basic unit of work in a run
         environment: # environment variables for primary container
           PIPENV_VENV_IN_PROJECT: "true"
     steps: # steps that comprise the `build` job
-      - checkout # check out source code to working directory
+      - *prepare
       - run:
           name: Install Node.js and yarn
           command: |
@@ -24,14 +35,6 @@ jobs: # A basic unit of work in a run
             curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
             echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
             sudo apt update && sudo apt install yarn
-      - run:
-          name: Install pipenv
-          command: |
-            sudo pip install pipenv
-            pipenv install -e .[dev]
-            pipenv update
-            echo 'export VENV_HOME_DIR=$(pipenv --venv)' >> $BASH_ENV
-            echo 'source $VENV_HOME_DIR/bin/activate' >> $BASH_ENV
       - run:
           name: Install pyright and run all checks
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
       - test-3.6
       - test-3.7
       - test-3.8
+      - check-formatting-3.7
 
 install-venv: &install-venv
   run:
@@ -46,7 +47,7 @@ jobs: # A basic unit of work in a run
           command: |
             git clone https://github.com/meeshkan/meeshkan-examples.git  ../meeshkan-examples
             cd ../meeshkan-examples && python run_all.py
-  format-3.7:
+  check-formatting-3.7:
     working_directory: ~/meeshkan
     docker:
       - image: circleci/python:3.7.6-stretch
@@ -55,6 +56,7 @@ jobs: # A basic unit of work in a run
       - *install-venv
       - run:
           command: |
+            set -eu -o pipefail
             python setup.py format
   test-3.7:
     <<: *test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,15 +7,13 @@ workflows:
       - test-3.7
       - test-3.8
 
-prepare: &prepare
-  - checkout # check out source code to working directory
-  - run:
-    name: Create virtualenvironment
-    command: |
-      python -m venv venv
-      . venv/bin/activate
-      pip install -e .[dev]
-      echo '. venv/bin/activate' >> $BASH_ENV
+install-venv: &install-venv
+  name: Create virtual environment
+  command: |
+    python -m venv venv
+    . venv/bin/activate
+    pip install -e .[dev]
+    echo '. venv/bin/activate' >> $BASH_ENV
 
 jobs: # A basic unit of work in a run
   test-3.6: &test-template # directory where steps are run
@@ -23,10 +21,10 @@ jobs: # A basic unit of work in a run
     docker: # run the steps with Docker
       # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
       - image: circleci/python:3.6.4-stretch
-        environment: # environment variables for primary container
-          PIPENV_VENV_IN_PROJECT: "true"
     steps: # steps that comprise the `build` job
-      - *prepare
+      - checkout
+      - run:
+          <<: *install-venv
       - run:
           name: Install Node.js and yarn
           command: |

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tests,tornado,typeguard,typing_extensions,urllib3,yaml
+known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tornado,typeguard,typing_extensions,urllib3,yaml

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,4 +4,5 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
+skip=venv
 known_third_party = click,clint,faker,faust,genson,hamcrest,http_types,jsonpath_rw,jsonschema,lenses,openapi_typed_2,pkg_resources,progress,psutil,pyfiglet,pytest,requests,requests_mock,setuptools,tornado,typeguard,typing_extensions,urllib3,yaml

--- a/meeshkan/build/builder.py
+++ b/meeshkan/build/builder.py
@@ -1,53 +1,52 @@
+from dataclasses import replace
 from functools import reduce
-
 from typing import (
     Any,
-    List,
-    Sequence,
-    Iterable,
     AsyncIterable,
-    cast,
-    Tuple,
-    Optional,
-    Union,
-    TypeVar,
-    Type,
+    Iterable,
+    List,
     Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+    cast,
 )
 from urllib.parse import urlunsplit
 
-from dataclasses import replace
 from http_types import HttpExchange as HttpExchange
 from openapi_typed_2 import (
-    Info,
-    Paths,
-    MediaType,
     Header,
+    Info,
+    MediaType,
     OpenAPIObject,
-    PathItem,
-    Response,
     Operation,
     Parameter,
+    PathItem,
+    Paths,
     Reference,
-    Server,
-    Responses,
     RequestBody,
+    Response,
+    Responses,
+    Server,
 )
 
+from ..logger import get as getLogger
 from .media_types import (
-    infer_media_type_from_nonempty,
-    build_media_type,
-    update_media_type,
     MediaTypeKey,
+    build_media_type,
+    infer_media_type_from_nonempty,
+    update_media_type,
     update_text_schema,
 )
-from .operation import operation_from_string, new_path_item_at_operation
+from .operation import new_path_item_at_operation, operation_from_string
 from .param import ParamBuilder
 from .paths import find_matching_path
 from .result import BuildResult
 from .servers import normalize_path_if_matches
 from .update_mode import UpdateMode
-from ..logger import get as getLogger
 
 _DEFAULT_PATH_ITEM = {
     "servers": None,

--- a/meeshkan/build/media_types.py
+++ b/meeshkan/build/media_types.py
@@ -1,12 +1,13 @@
 """Code for building and inferring media types (application/json, text/plain, etc.) from HTTP exchanges."""
-from .update_mode import UpdateMode
-from ..logger import get as getLogger
-from typing import Any, Sequence, cast, Optional
-from openapi_typed_2 import MediaType, Schema, convert_to_Schema
 import json
-from typing_extensions import Literal
-from .json_schema import to_openapi_json_schema
+from typing import Any, Optional, Sequence, cast
 
+from openapi_typed_2 import MediaType, Schema, convert_to_Schema
+from typing_extensions import Literal
+
+from ..logger import get as getLogger
+from .json_schema import to_openapi_json_schema
+from .update_mode import UpdateMode
 
 logger = getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -191,12 +191,6 @@ class TestCommand(SetupCommand):
     description = "Run tests, formatting, type-checks, and linting"
 
     def run(self):
-        self.status("Checking formatting...")
-        check_formatting()
-
-        self.status("Checking style...")
-        check_style()
-
         self.status("Checking types...")
         type_check()
 

--- a/setup.py
+++ b/setup.py
@@ -122,11 +122,7 @@ TEST_COMMAND = "pytest"
 
 LINT_COMMAND = "flake8 --exclude .git,.venv,__pycache__,build,dist"
 
-BLACK_FORMAT_COMMAND = "black ."
-ISORT_FORMAT_COMMAND = "isort -y"
-
-BLACK_CHECK_COMMAND = "black --check ."
-ISORT_CHECK_COMMAND = "pipenv run isort --check-only"
+PRECOMMIT_COMMAND = "pre-commit run --all-files"
 
 
 def build():
@@ -146,13 +142,11 @@ def check_style():
 
 
 def enforce_formatting():
-    run_sys_command(ISORT_FORMAT_COMMAND, "Formatting with isort failed")
-    run_sys_command(BLACK_FORMAT_COMMAND, "Formatting with black failed")
+    run_sys_command(PRECOMMIT_COMMAND, "Formatting with precommit failed")
 
 
 def check_formatting():
-    run_sys_command(ISORT_CHECK_COMMAND, "Checking with isort failed")
-    run_sys_command(BLACK_CHECK_COMMAND, "Checking with black failed")
+    run_sys_command(PRECOMMIT_COMMAND, "Formatting with precommit failed")
 
 
 class BuildDistCommand(SetupCommand):

--- a/tests/build/test_builder.py
+++ b/tests/build/test_builder.py
@@ -1,24 +1,21 @@
 import json
+import time
+from dataclasses import replace
 
 import pytest
-from dataclasses import replace
 from hamcrest import *
-from http_types import HttpExchange, Response, RequestBuilder, HttpExchangeBuilder
-from meeshkan.build import build_schema_batch, update_openapi, build_schema_online
-from meeshkan.build.builder import BASE_SCHEMA
-from meeshkan.build.update_mode import UpdateMode
-from openapi_typed_2 import (
-    OpenAPIObject,
-    Operation,
-    PathItem,
-    Schema,
-    Response as _Response,
-)
-from openapi_typed_2 import convert_to_openapi
+from http_types import HttpExchange, HttpExchangeBuilder, RequestBuilder, Response
+from openapi_typed_2 import OpenAPIObject, Operation, PathItem
+from openapi_typed_2 import Response as _Response
+from openapi_typed_2 import Schema, convert_to_openapi
 from typeguard import check_type
 from yaml import safe_load
 
-from ..util import read_recordings_as_request_response, POKEAPI_RECORDINGS_PATH
+from meeshkan.build import build_schema_batch, build_schema_online, update_openapi
+from meeshkan.build.builder import BASE_SCHEMA
+from meeshkan.build.update_mode import UpdateMode
+
+from ..util import POKEAPI_RECORDINGS_PATH, read_recordings_as_request_response
 
 requests = read_recordings_as_request_response()
 pokeapi_requests = read_recordings_as_request_response(POKEAPI_RECORDINGS_PATH)
@@ -287,12 +284,6 @@ def test_schema_in_replay_mode():
         .schema.oneOf
     )
 
-
-# TODO
-# this sullies the structure of the repo a bit as
-# we are reading from an odd loation
-# given where this test lives
-import time
 
 ACCEPTABLE_TIME = 10  # 10 seconds
 


### PR DESCRIPTION
- Doesn't handle workspace persistence or any kind of workflow optimization
- Uses `pre-commit run --all-files` when `python setup.py format` is run
- Fixes broken formatting in `meeshkan/build` and `tests/build`