### PR TITLE
Downgrade graphql dependency to v14.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "gatsby-transformer-remark": "2.7.1",
     "gatsby-transformer-sharp": "2.3.19",
     "gatsby-transformer-yaml": "2.3.1",
-    "graphql": "^15.4.0",
+    "graphql": "14.7.0",
     "graphql-scalars": "^1.4.1",
     "graphql-tools": "^7.0.1",
     "mixpanel-browser": "2.38.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12297,14 +12297,14 @@ graphql-upload@^8.0.2:
     http-errors "^1.7.3"
     object-path "^0.11.4"
 
-graphql@^14.6.0, graphql@^14.7.0:
+graphql@14.7.0, graphql@^14.6.0, graphql@^14.7.0:
   version "14.7.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
   integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
   dependencies:
     iterall "^1.2.2"
 
-graphql@^15.3.0, graphql@^15.4.0:
+graphql@^15.3.0:
   version "15.4.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.4.0.tgz#e459dea1150da5a106486ba7276518b5295a4347"
   integrity sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA==


### PR DESCRIPTION
- See https://linear.app/meeshkan/issue/MEM-1343/downgrade-graphql-version-in-frontend-monorepo.