### PR TITLE
Re-fetch user context when user gets updated

### DIFF
--- a/apps/webapp/components/molecules/create-project-form.tsx
+++ b/apps/webapp/components/molecules/create-project-form.tsx
@@ -7,6 +7,7 @@ import {
 	Input,
 } from '@chakra-ui/react';
 import { useForm } from 'react-hook-form';
+import { mutate } from 'swr';
 import AvatarField from './avatar-field';
 import { UserContext, AvatarFile } from '../../utils/user';
 import { createProject } from '../../utils/project';
@@ -47,6 +48,7 @@ const CreateProjectForm = ({ setLoading }: CreateProjectFormProps) => {
             return;
         }
 
+		mutate('/api/session');
 		router.reload();
 	};
 

--- a/apps/webapp/components/molecules/update-profile-form.tsx
+++ b/apps/webapp/components/molecules/update-profile-form.tsx
@@ -13,6 +13,7 @@ import {
 } from '@chakra-ui/react';
 import { ArrowUpDownIcon } from '@chakra-ui/icons';
 import { useForm } from 'react-hook-form';
+import { mutate } from 'swr';
 import AvatarField from '../molecules/avatar-field';
 import {
 	UserContext,
@@ -59,6 +60,7 @@ const UpdateProfileForm = ({ setLoading, setStep, formId = 'form' }: UpdateProfi
 			setStep(2);
 		}
 
+		mutate('/api/session');
 		setLoading(false);
 	};
 

--- a/apps/webapp/components/molecules/update-project-form.tsx
+++ b/apps/webapp/components/molecules/update-project-form.tsx
@@ -13,6 +13,7 @@ import {
 } from '@chakra-ui/react';
 import { ArrowUpDownIcon } from '@chakra-ui/icons';
 import { useForm } from 'react-hook-form';
+import { mutate } from 'swr';
 import AvatarField from '../molecules/avatar-field';
 import { UserContext, AvatarFile } from '../../utils/user';
 import { updateProject } from '../../utils/project';
@@ -47,6 +48,7 @@ const UpdateProjectForm = ({ setLoading }: UpdateProjectFormProps) => {
 			return;
 		}
 
+		mutate('/api/session');
 		setLoading(false);
 	};
 


### PR DESCRIPTION
- Whenever a user-related attribute is updated, re-fetch `/api/session`.
- This means that you shouldn't need to refresh the page after any updates in settings, for instance.