### PR TITLE
Fix delete user stories when rejected

### DIFF
--- a/apps/webapp/graphql/user-story.ts
+++ b/apps/webapp/graphql/user-story.ts
@@ -67,7 +67,7 @@ export const UPDATE_EXPECTED_TEST = gql`
 
 export const DELETE_REJECTED_RECORDING = gql`
 	mutation DELETE_REJECTED_RECORDING($userStoryId: ID!) {
-		userStoryDelete(filter: { id: $userStoryId }) {
+		userStoryDelete(filter: { id: $userStoryId }, force: true) {
 			success
 		}
 	}

--- a/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
+++ b/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
@@ -243,7 +243,7 @@ const UserStory = (props: UserStoryProps) => {
 						variant="subtle"
 						leftIcon={<XmarkIcon />}
 						onClick={() => {
-							deleteRejectedRecording;
+							deleteRejectedRecording();
 							toast({
 								position: 'bottom-right',
 								render: () => (


### PR DESCRIPTION
To test this — 
1. Click on a user story from `/[projectName]/user-stories`
2. Copy the id in the URL
3. Click the Reject button. 
4. Run this mutation with the `userStoryID` variable assigned to your copied id.
```graphql
query GET_DELETED_USER_STORY($userStoryID: ID!){
  userStory(id: $userStoryID) {
    title
    significance
  }
}
```
5. If it comes back as null, that's expected. To the arguments, add `withDeleted: true`. You should now see the userStory details.