### PR TITLE
Empty state of last case on test runs page

### DIFF
--- a/apps/webapp/pages/[projectName]/test-runs/index.tsx
+++ b/apps/webapp/pages/[projectName]/test-runs/index.tsx
@@ -147,14 +147,14 @@ const TestRunsPage = () => {
 			</GridCard>
 			{testRuns.length > 0 ? (
 				<Stack spacing={6} overflowY="scroll">
-					{testRuns.map((testRun, index) => {
+					{testRuns.slice(0).reverse().map((testRun, index) => {
 						const { id, status, createdAt } = testRun;
 						return (
 							<TestRunCard
 								id={id}
 								key={id}
 								status={status}
-								runNumber={index + 1}
+								runNumber={testRuns.length - index}
 								date={new Date(createdAt)}
 								stats={_.countBy(
 									testRun.testOutcome.items.map((outcome) => outcome.status)


### PR DESCRIPTION
- The grid card at the top of the test runs page should show an 'error' message in the case that there are no test cases with expected status for it (instead of disappearing).
- Fix the order of the test runs in the list as well as the order of the test run number.