### PR TITLE
Fix refresh bug on individual test run & user story pages

### DIFF
--- a/apps/webapp/hocs/with-auth.tsx
+++ b/apps/webapp/hocs/with-auth.tsx
@@ -24,9 +24,20 @@ const withAuth = (PageComponent) => {
 
 		useEffect(() => {
 			if (slugifiedProjectName) {
-				router.push(router.pathname.includes('[projectName]')
-					? router.pathname.replace('[projectName]', slugifiedProjectName)
-					: `/${slugifiedProjectName}`);
+				let url = router.pathname;
+				const query = router.query;
+				query.projectName = slugifiedProjectName;
+				Object.keys(query).forEach(
+					param => {
+						url = url.replace(`[${param as string}]`, query[param] as string);
+					}
+				);
+
+				if (url === '/') {
+					url = `/${slugifiedProjectName}`;
+				}
+
+				router.push(url);
 			}
 		}, [slugifiedProjectName]);
 

--- a/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
+++ b/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
@@ -55,8 +55,8 @@ const UserStory = (props: UserStoryProps) => {
 	const router = useRouter();
 	const toast = useToast();
 
-	const slugifiedProjectName = useMemo(() => createSlug(project.name), [
-		project.name,
+	const slugifiedProjectName = useMemo(() => createSlug(project?.name || ''), [
+		project?.name,
 	]);
 
 	const { userStoryId } = router.query;
@@ -67,7 +67,7 @@ const UserStory = (props: UserStoryProps) => {
 	// Initial data fetch
 	const fetcher = (query) =>
 		client.request(query, {
-			projectId: project.id,
+			projectId: project?.id,
 			userStoryId: userStoryId,
 		});
 
@@ -113,7 +113,7 @@ const UserStory = (props: UserStoryProps) => {
 		return <LoadingScreen as={Card} />;
 	}
 
-	if (!foundProject) {
+	if (!foundProject || data?.userStory === null) {
 		return <NotFoundError />;
 	}
 

--- a/apps/webapp/pages/[projectName]/user-stories/index.tsx
+++ b/apps/webapp/pages/[projectName]/user-stories/index.tsx
@@ -157,7 +157,7 @@ const UserStoriesPage = ({ cookies }: UserStoryProps) => {
 		[]
 	);
 
-	const projectId = project.id;
+	const projectId = project?.id;
 	const fetchData = useCallback(
 		({ pageSize, pageIndex, ...rest }) => {
 			const client = eightBaseClient(idToken);
@@ -181,8 +181,8 @@ const UserStoriesPage = ({ cookies }: UserStoryProps) => {
 		setPagination({ page: pageIndex, rowsPerPage: pageSize });
 	}, []);
 
-	const slugifiedProjectName = useMemo(() => createSlug(project.name), [
-		project.name,
+	const slugifiedProjectName = useMemo(() => createSlug(project?.name || ''), [
+		project?.name,
 	]);
 
 	const handleEdit = (id: string) => {


### PR DESCRIPTION
- The `[userStoryId]` page currently breaks when a non-existent ID is passed to it. Instead, it should probably be returning a 404 error.
- The `[testId]` page does a weird redirect on non-existent IDs.
- This PR fixes those issues, also allowing you to refresh on those pages without an internal error nor weird redirects.