### PR TITLE
Fix broken invite links

### DIFF
--- a/apps/webapp/graphql/project.ts
+++ b/apps/webapp/graphql/project.ts
@@ -92,7 +92,17 @@ export const JOIN_PROJECT = gql`
 					shareUrl
 				}
 				configuration {
+					productionURL
+					stagingURL
 					inviteLink
+					authenticationTokens {
+						items {
+							id
+							type
+							key
+							value
+						}
+					}
 				}
 				hasReceivedEvents
 				members {
@@ -110,35 +120,57 @@ export const JOIN_PROJECT = gql`
 					count
 					items {
 						id
-						failing {
-							count
+						testOutcome {
 							items {
-								firstIntroduction
+								status
 								isResolved
+								error
+								createdAt
+								video {
+									downloadUrl
+									shareUrl
+								}
 							}
 						}
 						title
 						testCreatedDate
 						isTestCase
 						createdAt
-						testRuns {
-							count
-							items {
-								status
-								dateTime
-								userStories {
-									items {
-										id
-									}
-								}
-							}
-						}
 					}
 				}
 				release {
 					count
 					items {
+						id
+						name
 						releaseDate
+						testRuns {
+							count
+							items {
+								id
+								status
+								ciRun
+								createdAt
+								testLength
+								testOutcome {
+									count
+									items {
+										status
+										isResolved
+										error
+										createdAt
+										video {
+											downloadUrl
+											shareUrl
+										}
+										userStory {
+											id
+											title
+										}
+									}
+								}
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
- Update the `JOIN_PROJECT` GraphQL mutation to abide by the new schema.