### PR TITLE
fix: Don't crop videos

### DIFF
--- a/apps/webapp/components/atoms/video-player.tsx
+++ b/apps/webapp/components/atoms/video-player.tsx
@@ -1,20 +1,32 @@
 import React from 'react';
-// import { AspectRatio, useColorModeValue } from '@chakra-ui/react';
+import {
+	useBreakpointValue,
+	useColorModeValue,
+	useToken,
+} from '@chakra-ui/react';
 
-const VideoPlayer = ({ children }) => (
-	// <AspectRatio
-	// 	ratio={16 / 9}
-	// 	borderRadius="md"
-	// 	overflow="hidden"
-	// 	border="1px solid"
-	// 	borderColor={useColorModeValue('gray.200', 'gray.700')}
-	// 	backgroundColor="red.500"
-	// >
-	<video style={{ borderRadius: '6px' }} controls>
-		{children}
-		Your browser does not support the video tag.
-	</video>
-	// </AspectRatio>
-);
+const VideoPlayer = ({ children }) => {
+	const [gray200, gray700] = useToken('colors', ['gray.200', 'gray.700']);
+	const maxHeight = useBreakpointValue({
+		base: '75vw',
+		md: '15vw',
+	});
+	return (
+		<video
+			style={{
+				borderRadius: '6px',
+				height: '100%',
+				maxHeight: maxHeight,
+				border: '1px solid',
+				borderColor: useColorModeValue(gray200, gray700),
+				backgroundColor: 'black',
+			}}
+			controls
+		>
+			{children}
+			Your browser does not support the video tag.
+		</video>
+	);
+};
 
 export default VideoPlayer;


### PR DESCRIPTION
In order to be able to expect the same size of video each time, we wrapped the video tag in an `AspectRatio` box. This also cropped video that didn't fit the ratio instead of adding background. Now we add background to expect the size of the video each time.

Before
![image](https://user-images.githubusercontent.com/32865577/108667749-22c59a00-74da-11eb-8bb5-a4b339622790.png)

After
![image](https://user-images.githubusercontent.com/32865577/108667608-e2feb280-74d9-11eb-8f5d-345eb7799b6a.png)

---
Before
![image](https://user-images.githubusercontent.com/32865577/108667791-353fd380-74da-11eb-9636-56a77f8cef7a.png)

After
![image](https://user-images.githubusercontent.com/32865577/108667640-f14cce80-74d9-11eb-8fed-f744460cc231.png)
