### PR TITLE
Fix script card `hasReceivedEvents` check

### DIFF
--- a/apps/webapp/components/organisms/grid.tsx
+++ b/apps/webapp/components/organisms/grid.tsx
@@ -118,10 +118,6 @@ const Grid = (props: StackProps) => {
 		selectedProject.name,
 	]);
 
-	const [showScript, setShowScript] = useState<boolean>(
-		!selectedProject?.hasReceivedEvents
-	);
-
 	const doughnutOptions: ChartOptions = {
 		legend: {
 			align: 'center',
@@ -183,8 +179,10 @@ const Grid = (props: StackProps) => {
 
 	const [version, setVersion] = useState(versions[0]);
 	const [timePeriod, setTimePeriod] = useState('7 days');
+	const [showScript, setShowScript] = useState(false);
 
 	useEffect(() => setVersion(versions[0]), [versions]);
+	useEffect(() => setShowScript(!selectedProject.hasReceivedEvents), [selectedProject]);
 
 	const userStories: UserStoryListResponse['items'] =
 		selectedProject.userStories.items;


### PR DESCRIPTION
- The script card never appeared for any project in the dashboard.

Testing instructions:
- Choose Wing, Meeshkan webapp and other projects for which we know we have events in the DB. The script _should not_ appear in the dashboard.
- Choose a test project with no events. There _should_ be a test script in the dashboard.