### PR TITLE
Use native `Date` instead of `moment`

### DIFF
--- a/apps/webapp/components/organisms/grid.tsx
+++ b/apps/webapp/components/organisms/grid.tsx
@@ -42,8 +42,8 @@ import {
 	getLatestTestStates,
 	getRecordingsAndTestsByDay,
 	sumOfObjectValues,
-	getLastNDaysInFormat,
 } from '../../utils/metrics';
+import { lastNDays } from '../../utils/date';
 import { ChartOptions, ChartData } from 'chart.js';
 require('../molecules/rounded-chart');
 
@@ -238,9 +238,8 @@ const Grid = (props: StackProps) => {
 
 	barData.datasets[0].data = Object.values(recordingsByDay);
 	barData.datasets[1].data = Object.values(testsByDay);
-	const barDataLabels = getLastNDaysInFormat(
-		selectedTimePeriodInDays,
-		'MMM DD'
+	const barDataLabels = lastNDays(selectedTimePeriodInDays).map((date: Date) =>
+		date.toLocaleDateString('en-US', { month: 'short', day: '2-digit' })
 	);
 	barData.labels = barDataLabels;
 

--- a/apps/webapp/utils/date.ts
+++ b/apps/webapp/utils/date.ts
@@ -4,3 +4,24 @@ export const getDateInEightBaseFormat = (date: Date): string => {
     const dd = date.getDate();
     return `${yyyy}-${(mm > 9 ? '' : '0') + mm}-${(dd > 9 ? '' : '0') + dd}`;
 };
+
+export const daysUntilDate = (date: Date): number =>
+	Math.ceil((new Date().getTime() - date.getTime()) / (1000 * 3600 * 24));
+
+export const lastNDays = (n: number): Date[] => {
+	return [...Array(n).keys()]
+		.map((i) => {
+			const date = new Date();
+			date.setDate(date.getDate() - i);
+			return date;
+		})
+		.reverse();
+};
+
+export const isSameDay = (dateA: Date, dateB: Date): boolean => {
+	return (
+		dateA.getDate() === dateB.getDate() &&
+		dateA.getMonth() === dateB.getMonth() &&
+		dateA.getFullYear() === dateB.getFullYear()
+	);
+};

--- a/apps/webapp/utils/metrics.ts
+++ b/apps/webapp/utils/metrics.ts
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import moment from 'moment';
+import { daysUntilDate, lastNDays, isSameDay } from './date';
 import {
 	UserStoryListResponse,
 	Project,
@@ -9,9 +9,6 @@ import {
 	DataPoint,
 	DataPointTag,
 } from '@frontend/meeshkan-types';
-
-const daysUntilDate = (date: moment.Moment): number =>
-	date.diff(moment(), 'days');
 
 export const getTestRuns = (releases: ReleaseListResponse['items']) => {
 	const testRunsTotal = releases.reduce(
@@ -39,7 +36,7 @@ export const getTestRuns = (releases: ReleaseListResponse['items']) => {
 export const getDaysUntilRelease = (project: Project) => {
 	const [release] = project.release.items;
 	const releaseDate = release.releaseDate;
-	return releaseDate ? daysUntilDate(moment(releaseDate)) : null;
+	return releaseDate ? daysUntilDate(new Date(releaseDate)) : null;
 };
 
 export const getBugs = (testRuns: TestRunListResponse['items']) => {
@@ -83,9 +80,6 @@ export const getLatestTestStates = (testRuns: TestRunListResponse['items']) => {
 	return latestTestStates;
 };
 
-const lastNDays = (n: number) =>
-	[...Array(n).keys()].map((i) => moment().subtract(i, 'days')).reverse();
-
 export const getRecordingsAndTestsByDay = (
 	days: number,
 	userStories: UserStoryListResponse['items']
@@ -95,12 +89,12 @@ export const getRecordingsAndTestsByDay = (
 	lastNDays(days).forEach((day) => {
 		const recordingsOnThisDay = userStories.filter((story) => {
 			const { createdAt, isTestCase } = story;
-			return moment(createdAt).isSame(day, 'day') && !isTestCase;
+			return isSameDay(new Date(createdAt), day) && !isTestCase;
 		});
 		const testsOnThisDay = userStories.filter((story) => {
 			const { testCreatedDate, isTestCase } = story;
 			return testCreatedDate
-				? moment(testCreatedDate).isSame(day, 'day') && isTestCase
+				? isSameDay(new Date(testCreatedDate), day) && isTestCase
 				: false;
 		});
 		const dayValue = day.valueOf();
@@ -115,9 +109,6 @@ export const getRecordingsAndTestsByDay = (
 
 export const sumOfObjectValues = (object: { [key: string]: number }) =>
 	_.sum(_.values(object));
-
-export const getLastNDaysInFormat = (days: number, format: string) =>
-	lastNDays(days).map((day) => day.format(format));
 
 export const COVERAGE_DATA_POINT = 'COVERAGE_DATA_POINT';
 export const MAX_POSSIBLE_TEST_COVERAGE_SCORE = 30;


### PR DESCRIPTION
As Makenna pointed out, moment is now in maintenance mode, therefore we should remove it in favor of native JS date features.