### PR TITLE
Fix missing tick icon in project selector menu

### DIFF
--- a/apps/webapp/components/molecules/sidebar-footer.tsx
+++ b/apps/webapp/components/molecules/sidebar-footer.tsx
@@ -86,14 +86,14 @@ const SideBarFooter = ({ isSettings = false }: SideBarFooterProps) => {
 					</MenuButton>
 					<MenuList>
 						<MenuOptionGroup
-							defaultValue={project?.name}
+							value={project?.id}
 							title="Projects"
 							type="radio"
 						>
 							{projects.map((project) => (
 								<MenuItemOption
 									key={project.id}
-									value={project.name}
+									value={project.id}
 									onClick={() => setProject(project)}
 								>
 									<Flex display="flex" alignItems="center">


### PR DESCRIPTION
- Right after login, users are redirected to a project. When this happens, the project selection menu should have a 'tick' icon next to the current project's icon, instead of a blank space. See linear ticket for PoC pictures.