### PR TITLE
Fix project selection menu cut name

### DIFF
--- a/apps/webapp/components/molecules/sidebar-footer.tsx
+++ b/apps/webapp/components/molecules/sidebar-footer.tsx
@@ -73,6 +73,7 @@ const SideBarFooter = ({ isSettings = false }: SideBarFooterProps) => {
 						size="sm"
 						colorScheme="gray"
 						backgroundColor={menuButtonBackgroundColor}
+						textAlign="left"
 						display="block"
 					>
 						<Flex


### PR DESCRIPTION
- The project selection menu cuts the project name text.

Testing:
- Use this invite link to join _Yet Another Project With a Long Name_: [https://app.meeshkan.com/invite/hrzZaDsu](https://app.meeshkan.com/invite/hrzZaDsu).