### PR TITLE
Fix user story showing previous story data

### DIFF
--- a/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
+++ b/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
@@ -246,7 +246,7 @@ const UserStoryPage = (props: UserStoryProps) => {
 		).then(() => setTimeout(() => setLoading(false), 30000));
 	};
 
-	if ((validatingQuery && !data) || validatingProject) {
+	if ((validatingQuery && (!data || data?.userStory?.id !== userStoryId)) || validatingProject) {
 		return <LoadingScreen as={Card} />;
 	}
 


### PR DESCRIPTION
- Individual user story page shows previous user story's data momentarily.
- This issue was introduced by PR #121.