### PR TITLE
Fix tiny video player bug

### DIFF
--- a/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
+++ b/apps/webapp/pages/[projectName]/user-stories/[userStoryId].tsx
@@ -484,7 +484,7 @@ const UserStoryPage = (props: UserStoryProps) => {
 							<CheckmarkIcon color={stepNumberColor} />
 						</Flex>
 					</Box>
-					<Box>
+					<Box minW="md">
 						{data.userStory?.recording?.video ? (
 							<VideoPlayer
 								src={data.userStory.recording.video.downloadUrl}


### PR DESCRIPTION
- The video player's dimensions are too small and vary from user story to user story. Instead, it should be the text that varies in width depending on how long the text is.
- Example of bug: [app.meeshkan.com/meeshkan-webapp/user-stories/ckneeirzs001s08mi9lab38rb](https://app.meeshkan.com/meeshkan-webapp/user-stories/ckneeirzs001s08mi9lab38rb)