### PR TITLE
feat: Manually trigger test runs

### DIFF
--- a/apps/webapp/pages/[projectName]/test-runs/index.tsx
+++ b/apps/webapp/pages/[projectName]/test-runs/index.tsx
@@ -97,14 +97,7 @@ const TestRunsPage = () => {
 		setTestTriggering(true);
 		try {
 			await fetch(
-				process.env.VERCEL_ENV === 'preview' ||
-					process.env.VERCEL_ENV === 'development' ||
-					process.env.NODE_ENV === 'development'
-					? 'https://t9ky8625ne.execute-api.eu-west-1.amazonaws.com/staging/test-trigger'
-					: process.env.NODE_ENV === 'production' ||
-					  process.env.VERCEL_ENV === 'production'
-					? 'https://7cs97h8es9.execute-api.eu-west-1.amazonaws.com/main/test-trigger'
-					: 'https://7cs97h8es9.execute-api.eu-west-1.amazonaws.com/main/test-trigger',
+				process.env.NEXT_PUBLIC_TEST_TRIGGER_ENDPOINT || 'https://7cs97h8es9.execute-api.eu-west-1.amazonaws.com/main/test-trigger',
 				{
 					method: 'POST',
 					mode: 'no-cors',


### PR DESCRIPTION
- Depending on the environment you're on, trigger a test. 
  - Local/preview/development -> staging trigger (writes to staging 8base)
  - Production -> main trigger (writes to prod 8base)

Not in scope — [limit # of test runs](https://linear.app/meeshkan/issue/DEV-1879/limit-number-of-test-runs) and disable this button when monthly quota is reached. 