### PR TITLE
Support localStorage key-values in Puppeteer script

### DIFF
--- a/libs/downloadable-script/src/lib/downloadable-script.ts
+++ b/libs/downloadable-script/src/lib/downloadable-script.ts
@@ -40,12 +40,19 @@ const topMatterPptr = (
   let ddDestinationBB;
 
 ` +
-		(authTokens && stagingURL
-			? `  await page.setCookie({ name: ${JSON.stringify(
-					authTokens[0]?.key
-			  )}, value: ${JSON.stringify(
-					authTokens[0]?.value
-			  )}, domain: ${JSON.stringify(new URL(stagingURL).hostname)}  })`
+		((authTokens && authTokens.length > 0 && stagingURL)
+            ? authTokens.map(({ key, value, type }) => type === 'local storage'
+                ? `  await page.evaluateOnNewDocument(() => { localStorage.setItem(${JSON.stringify(
+                        key
+                    )}, ${JSON.stringify(
+                        value
+                    )}); });`
+                : `  await page.setCookie({ name: ${JSON.stringify(
+                    key
+			    )}, value: ${JSON.stringify(
+                    value
+			    )}, domain: ${JSON.stringify('.' + new URL(stagingURL).hostname)}  });`
+              ).join('\n')
 			: '')
 	);
 };


### PR DESCRIPTION
- Inject all cookies _and_ local storage key-value pairs in Puppeteer script.
- This also fixes [dev-1897](https://linear.app/meeshkan/issue/DEV-1897/add-dot-prefix-to-domains-in-puppeteer-setcookie).