### PR TITLE
Make Auth0 the login page

### DIFF
--- a/apps/webapp/hooks/use-first-render.tsx
+++ b/apps/webapp/hooks/use-first-render.tsx
@@ -1,0 +1,8 @@
+import { useRef } from 'react';
+
+export const useFirstRender = () => {
+	const ref = useRef(true);
+	const firstRender = ref.current;
+	ref.current = false;
+	return firstRender;
+};


### PR DESCRIPTION
- Instead of having a "sign in / sign up" button as the login page, simply redirect to Auth0, instead.
- When testing, please make sure to test the invite link.