### PR TITLE
Don't show plan popup when updating project config

### DIFF
--- a/apps/webapp/components/templates/layout.tsx
+++ b/apps/webapp/components/templates/layout.tsx
@@ -74,7 +74,7 @@ const Layout = ({ children, ...props }: LayoutProps) => {
 				{children}
 			</Stack>
 
-			{project && !project.configuration?.plan ? (
+			{project?.configuration && !project.configuration?.plan ? (
 				<Modal
 					isOpen={isOpen}
 					onClose={onClose}

--- a/apps/webapp/graphql/project.ts
+++ b/apps/webapp/graphql/project.ts
@@ -59,6 +59,11 @@ export const UPDATE_PROJECT = gql`
 			id
 			name
 			configuration {
+				plan
+				stripeCustomerID
+				billingInterval
+				subscriptionStatus
+				subscriptionStartedDate
 				inviteLink
 				productionURL
 				stagingURL
@@ -111,6 +116,11 @@ export const JOIN_PROJECT = gql`
 					productionURL
 					stagingURL
 					inviteLink
+					plan
+					stripeCustomerID
+					billingInterval
+					subscriptionStatus
+					subscriptionStartedDate
 					authenticationTokens {
 						items {
 							id


### PR DESCRIPTION
- Add plan info to project GQL mutation responses so that we don't show the billing & plan popup on project configuration updates.