### PR TITLE
Fetch `project.userStories.count` for extension handshake

### DIFF
--- a/apps/webapp/graphql/user.ts
+++ b/apps/webapp/graphql/user.ts
@@ -64,6 +64,9 @@ export const USER = gql`
 				items {
 					id
 					name
+					userStories {
+						count
+					}
 					configuration {
 						id
 						stagingURL

--- a/apps/webapp/utils/extension.ts
+++ b/apps/webapp/utils/extension.ts
@@ -62,6 +62,9 @@ export const handleExtensionAuthHandshake = (
 			id: project.id,
 			name: project.name,
 			avatar: project.avatar?.downloadUrl,
+			userStories: {
+				count: project.userStories.count,
+			},
 			configuration: {
 				id: project.configuration?.id,
 				stagingURL: project.configuration?.stagingURL,


### PR DESCRIPTION
- The extension needs to keep track of each project's `project.userStories.count` to determine whether to onboard or not.

Pre-merge TODO (in order):
- [x] Merge [github.com/meeshkan/meeshkan/pull/195](https://github.com/meeshkan/meeshkan/pull/195) to `staging`.
- [ ] Rebase on top of `staging`.